### PR TITLE
Add missing characters in generateLinks

### DIFF
--- a/LightShotRoulette/src/main/java/com/aliucord/lightshotroulette/lightshotRoulette.java
+++ b/LightShotRoulette/src/main/java/com/aliucord/lightshotroulette/lightshotRoulette.java
@@ -38,7 +38,7 @@ public class lightshotRoulette extends Plugin {
 
     public String generateLinks(long count) {
         String val = "";
-        String str = "abcdefghijklmnoprstuxwyz0123456789";
+        String str = "abcdefghijklmnopqrstuvwxyz0123456789";
         Random random = new Random();
         int charCount = 6;
         for (int j = 0; j < count; j++) {


### PR DESCRIPTION
I was looking through the given code to make a JS version, but noticed the character set you were using was odd. It is missing q and v, along with having w and x swapped. However, I still verified my assumptions and checked for valid prnt.sc links with q and v. 
q is valid as seen in https://prnt.sc/aek5ql
v is valid as seen in https://prnt.sc/8rvt57

Is there a reason for this? If not, this change simply adds q and v, and fixes the ordering of the alphabet.