### PR TITLE
PhotoEditor: v2.0.0

### DIFF
--- a/PhotoEditor/build.gradle.kts
+++ b/PhotoEditor/build.gradle.kts
@@ -11,14 +11,14 @@ aliucord {
 
     changelog.set(
         """
-        # 1.1.0-dev
-        * Revamped UI with a categorized sub-toolbar
-        * Tap images to edit them instantly (no more bottom sheet!)
+        # 2.0.0-dev
+        * Added a dedicated Settings Page for the plugin!
+        * Tapping an image to edit it instantly is now an optional toggle in settings (Classic Bottom Sheet is back to being the default)
         * Added Delete & Spoiler buttons right inside the editor
         * Added a native Discord-style visual overlay for spoilers that hides when you touch the screen
         * Smoother animations and ripples
         * Fixed critical bug where selecting a sticker in the editor sent it to chat (caused by conflict with the FakeStickers plugin)
-        * Fixed "Could not open image editor" crashes caused by invalid window tokens
+        * Fixed "Could not open image editor" crashes caused by invalid window tokens by completely bulletproofing Activity fetching
         """.trimIndent(),
     )
 
@@ -37,3 +37,8 @@ dependencies {
     }
     compileOnly("org.jetbrains.kotlin:kotlin-stdlib:2.2.0")
 }
+
+
+
+
+

--- a/PhotoEditor/build.gradle.kts
+++ b/PhotoEditor/build.gradle.kts
@@ -15,7 +15,11 @@ aliucord {
         * Added a dedicated Settings Page for the plugin!
         * Tapping an image to edit it instantly is now an optional toggle in settings (Classic Bottom Sheet is back to being the default)
         * Added Delete & Spoiler buttons right inside the editor
+        * Moved the Save button to the top header for instant access without scrolling
         * Added a native Discord-style visual overlay for spoilers that hides when you touch the screen
+        * Restructured the toolbar to make Undo, Redo, and Reset global actions instead of burying them
+        * Replaced awkward placeholder icons with native Discord vectors
+        * The editor now instantly boots up with the Pen tool active and ready to draw
         * Smoother animations and ripples
         * Fixed critical bug where selecting a sticker in the editor sent it to chat (caused by conflict with the FakeStickers plugin)
         * Fixed "Could not open image editor" crashes caused by invalid window tokens by completely bulletproofing Activity fetching

--- a/PhotoEditor/build.gradle.kts
+++ b/PhotoEditor/build.gradle.kts
@@ -1,4 +1,4 @@
-version = "2.0.0-dev"
+version = "2.0.0"
 description = "Edit image URLs with PhotoEditor"
 
 
@@ -11,7 +11,7 @@ aliucord {
 
     changelog.set(
         """
-        # 2.0.0-dev
+        # 2.0.0
         
         # New Features & Enhancements
         * Added a dedicated Settings Page for the plugin

--- a/PhotoEditor/build.gradle.kts
+++ b/PhotoEditor/build.gradle.kts
@@ -25,6 +25,7 @@ aliucord {
         * Global Actions: Undo, Redo, and Reset are now global actions with dynamic state tracking (buttons grey out when there's nothing to undo)
 
         # UI & UX Polish
+        * Added long-press tooltips to all editor buttons (Draw, Text, Crop, etc.) to help new users
         * Replaced the S/L brush size buttons with a dynamic slider, locking the sub-toolbar in place
         * Added Delete, Spoiler, and Save buttons directly to the top header for instant access without scrolling
         * Implemented a native Discord-style visual Spoiler overlay that hides automatically when you touch the screen

--- a/PhotoEditor/build.gradle.kts
+++ b/PhotoEditor/build.gradle.kts
@@ -28,6 +28,9 @@ aliucord {
         * Created a powerful new Custom Filter engine that lets you build your own effects
         * Added Brightness, Contrast, Saturation, Hue, Temperature, and Tint sliders that can all be layered simultaneously
         * Fixed OpenGL occlusion bugs so live previews work instantly with custom ColorMatrix filters
+        * Upgraded the Crop Modal to feature full real-time Free Rotation and Mirroring
+        * Added a smooth -180° to 180° rotation slider, Flip H/V toggles, and a Rotate 90° snap button directly to the crop overlay
+        * Built a downscaled-preview rendering engine so the rotation slider is completely lag-free on all devices
         * Replaced awkward placeholder icons with native Discord vectors
         * The editor now instantly boots up with the Pen tool active and ready to draw
         * Smoother animations and ripples

--- a/PhotoEditor/build.gradle.kts
+++ b/PhotoEditor/build.gradle.kts
@@ -31,6 +31,8 @@ aliucord {
         * Upgraded the Crop Modal to feature full real-time Free Rotation and Mirroring
         * Added a smooth -180° to 180° rotation slider, Flip H/V toggles, and a Rotate 90° snap button directly to the crop overlay
         * Built a downscaled-preview rendering engine so the rotation slider is completely lag-free on all devices
+        * Turned the long-press Delete modal into a dynamic Overlay Options menu
+        * You can now long-press any Image, Sticker, or Emoji overlay and select "Crop" to individually crop and rotate that specific layer without affecting the background image!
         * Replaced awkward placeholder icons with native Discord vectors
         * The editor now instantly boots up with the Pen tool active and ready to draw
         * Smoother animations and ripples

--- a/PhotoEditor/build.gradle.kts
+++ b/PhotoEditor/build.gradle.kts
@@ -19,6 +19,8 @@ aliucord {
         * Added a native Discord-style visual overlay for spoilers that hides when you touch the screen
         * Restructured the toolbar to make Undo, Redo, and Reset global actions instead of burying them
         * Added dynamic state tracking so the Undo, Redo, and Reset buttons automatically grey out when there's nothing to undo
+        * Replaced the S/L brush size buttons with a dynamic slider, and locked the sub-toolbar in place to prevent accidental sliding
+        * Added a Custom Color Picker modal featuring HSV sliders, live HEX input, and an Eyedropper tool with drag-to-preview
         * Replaced awkward placeholder icons with native Discord vectors
         * The editor now instantly boots up with the Pen tool active and ready to draw
         * Smoother animations and ripples

--- a/PhotoEditor/build.gradle.kts
+++ b/PhotoEditor/build.gradle.kts
@@ -17,7 +17,7 @@ aliucord {
         * Added a dedicated Settings Page for the plugin
         * Added a "Quick Edit" toggle in settings to instantly edit images without opening the attachment menu
         * Brush Layer Engine: Added a new "Brush Layer Mode" to settings to control whether strokes draw behind, in front of, or weave between stickers
-        * Custom Filter Engine: Build your own effects using 6 simultaneous sliders (Brightness, Contrast, Saturation, Hue, Temperature, Tint)
+        * Custom Filter Engine: Build your own effects using 6 simultaneous sliders and optionally toggle the filter to apply to the entire image (including stickers/text) or just the background
         * Advanced Cropping: Added a lag-free real-time rotation slider (-180° to 180°), mirroring, and quick-snap rotation to the Crop Modal
         * Overlay Management: Long-press any sticker, emoji, or image overlay to open an Options Menu where you can individually crop and edit it without affecting the background
         * Color Picker Modal: A massive new picker with HSV sliders, live HEX input, and a drag-to-preview Eyedropper tool

--- a/PhotoEditor/build.gradle.kts
+++ b/PhotoEditor/build.gradle.kts
@@ -21,6 +21,10 @@ aliucord {
         * Added dynamic state tracking so the Undo, Redo, and Reset buttons automatically grey out when there's nothing to undo
         * Replaced the S/L brush size buttons with a dynamic slider, and locked the sub-toolbar in place to prevent accidental sliding
         * Added a Custom Color Picker modal featuring HSV sliders, live HEX input, and an Eyedropper tool with drag-to-preview
+        * Completely overhauled the Text Insertion Modal to feature a live preview input box and typography controls
+        * Built a searchable font engine that recursively parses .ttf/.otf files from your system and local storage
+        * Added a live font size slider and toggleable Bold, Italic, and Underline buttons
+        * The font dropdown is now fully theme-aware and flawlessly floats over the keyboard
         * Replaced awkward placeholder icons with native Discord vectors
         * The editor now instantly boots up with the Pen tool active and ready to draw
         * Smoother animations and ripples

--- a/PhotoEditor/build.gradle.kts
+++ b/PhotoEditor/build.gradle.kts
@@ -12,32 +12,30 @@ aliucord {
     changelog.set(
         """
         # 2.0.0-dev
-        * Added a dedicated Settings Page for the plugin!
-        * Tapping an image to edit it instantly is now an optional toggle in settings (Classic Bottom Sheet is back to being the default)
-        * Added Delete & Spoiler buttons right inside the editor
-        * Moved the Save button to the top header for instant access without scrolling
-        * Added a native Discord-style visual overlay for spoilers that hides when you touch the screen
-        * Restructured the toolbar to make Undo, Redo, and Reset global actions instead of burying them
-        * Added dynamic state tracking so the Undo, Redo, and Reset buttons automatically grey out when there's nothing to undo
-        * Replaced the S/L brush size buttons with a dynamic slider, and locked the sub-toolbar in place to prevent accidental sliding
-        * Added a Custom Color Picker modal featuring HSV sliders, live HEX input, and an Eyedropper tool with drag-to-preview
-        * Completely overhauled the Text Insertion Modal to feature a live preview input box and typography controls
-        * Built a searchable font engine that recursively parses .ttf/.otf files from your system and local storage
-        * Added a live font size slider and toggleable Bold, Italic, and Underline buttons
-        * The font dropdown is now fully theme-aware and flawlessly floats over the keyboard
-        * Created a powerful new Custom Filter engine that lets you build your own effects
-        * Added Brightness, Contrast, Saturation, Hue, Temperature, and Tint sliders that can all be layered simultaneously
-        * Fixed OpenGL occlusion bugs so live previews work instantly with custom ColorMatrix filters
-        * Upgraded the Crop Modal to feature full real-time Free Rotation and Mirroring
-        * Added a smooth -180° to 180° rotation slider, Flip H/V toggles, and a Rotate 90° snap button directly to the crop overlay
-        * Built a downscaled-preview rendering engine so the rotation slider is completely lag-free on all devices
-        * Turned the long-press Delete modal into a dynamic Overlay Options menu
-        * You can now long-press any Image, Sticker, or Emoji overlay and select "Crop" to individually crop and rotate that specific layer without affecting the background image!
-        * Replaced awkward placeholder icons with native Discord vectors
+        
+        # New Features & Enhancements
+        * Added a dedicated Settings Page for the plugin
+        * Added a "Quick Edit" toggle in settings to instantly edit images without opening the attachment menu
+        * Custom Filter Engine: Build your own effects using 6 simultaneous sliders (Brightness, Contrast, Saturation, Hue, Temperature, Tint)
+        * Advanced Cropping: Added a lag-free real-time rotation slider (-180° to 180°), mirroring, and quick-snap rotation to the Crop Modal
+        * Overlay Management: Long-press any sticker, emoji, or image overlay to open an Options Menu where you can individually crop and edit it without affecting the background
+        * Color Picker Modal: A massive new picker with HSV sliders, live HEX input, and a drag-to-preview Eyedropper tool
+        * Typography Engine: The Text Modal now features a live preview box, sizing sliders, and recursively parses local .ttf and .otf files for custom fonts
+        * Global Actions: Undo, Redo, and Reset are now global actions with dynamic state tracking (buttons grey out when there's nothing to undo)
+
+        # UI & UX Polish
+        * Replaced the S/L brush size buttons with a dynamic slider, locking the sub-toolbar in place
+        * Added Delete, Spoiler, and Save buttons directly to the top header for instant access without scrolling
+        * Implemented a native Discord-style visual Spoiler overlay that hides automatically when you touch the screen
+        * Replaced all awkward placeholder graphics with native Discord vector icons
         * The editor now instantly boots up with the Pen tool active and ready to draw
-        * Smoother animations and ripples
-        * Fixed critical bug where selecting a sticker in the editor sent it to chat (caused by conflict with the FakeStickers plugin)
-        * Fixed "Could not open image editor" crashes caused by invalid window tokens by completely bulletproofing Activity fetching
+        * Smoother animations, ripples, and a fully theme-aware layout that elegantly floats above keyboards
+
+        # Bug Fixes & Technical Improvements
+        * Built a downscaled-preview rendering engine so the crop rotation slider is completely lag-free on all devices
+        * Fixed OpenGL occlusion bugs so live previews work instantly with custom ColorMatrix filters
+        * Fixed a critical bug where selecting a sticker in the editor sent it to chat (resolved conflict with the FakeStickers plugin)
+        * Fixed "Could not open image editor" crashes caused by invalid window tokens by bulletproofing Activity fetching
         """.trimIndent(),
     )
 

--- a/PhotoEditor/build.gradle.kts
+++ b/PhotoEditor/build.gradle.kts
@@ -1,9 +1,28 @@
-version = "1.0.0"
+version = "2.0.0-dev"
 description = "Edit image URLs with PhotoEditor"
 
 
 android {
     namespace = "com.aliucord.plugins.photoeditor"
+}
+
+aliucord {
+    author("furqanhun", 0L, hyperlink = false)
+
+    changelog.set(
+        """
+        # 1.1.0-dev
+        * Revamped UI with a categorized sub-toolbar
+        * Tap images to edit them instantly (no more bottom sheet!)
+        * Added Delete & Spoiler buttons right inside the editor
+        * Added a native Discord-style visual overlay for spoilers that hides when you touch the screen
+        * Smoother animations and ripples
+        * Fixed critical bug where selecting a sticker in the editor sent it to chat (caused by conflict with the FakeStickers plugin)
+        * Fixed "Could not open image editor" crashes caused by invalid window tokens
+        """.trimIndent(),
+    )
+
+    deploy.set(true)
 }
 
 dependencies {
@@ -18,8 +37,3 @@ dependencies {
     }
     compileOnly("org.jetbrains.kotlin:kotlin-stdlib:2.2.0")
 }
-
-
-
-
-

--- a/PhotoEditor/build.gradle.kts
+++ b/PhotoEditor/build.gradle.kts
@@ -16,6 +16,7 @@ aliucord {
         # New Features & Enhancements
         * Added a dedicated Settings Page for the plugin
         * Added a "Quick Edit" toggle in settings to instantly edit images without opening the attachment menu
+        * Brush Layer Engine: Added a new "Brush Layer Mode" to settings to control whether strokes draw behind, in front of, or weave between stickers
         * Custom Filter Engine: Build your own effects using 6 simultaneous sliders (Brightness, Contrast, Saturation, Hue, Temperature, Tint)
         * Advanced Cropping: Added a lag-free real-time rotation slider (-180° to 180°), mirroring, and quick-snap rotation to the Crop Modal
         * Overlay Management: Long-press any sticker, emoji, or image overlay to open an Options Menu where you can individually crop and edit it without affecting the background

--- a/PhotoEditor/build.gradle.kts
+++ b/PhotoEditor/build.gradle.kts
@@ -35,6 +35,7 @@ aliucord {
         # Bug Fixes & Technical Improvements
         * Built a downscaled-preview rendering engine so the crop rotation slider is completely lag-free on all devices
         * Fixed OpenGL occlusion bugs so live previews work instantly with custom ColorMatrix filters
+        * Fixed a UI synchronization bug where the Draw toolbar would stay highlighted after opening other menus
         * Fixed a critical bug where selecting a sticker in the editor sent it to chat (resolved conflict with the FakeStickers plugin)
         * Fixed "Could not open image editor" crashes caused by invalid window tokens by bulletproofing Activity fetching
         """.trimIndent(),

--- a/PhotoEditor/build.gradle.kts
+++ b/PhotoEditor/build.gradle.kts
@@ -25,6 +25,9 @@ aliucord {
         * Built a searchable font engine that recursively parses .ttf/.otf files from your system and local storage
         * Added a live font size slider and toggleable Bold, Italic, and Underline buttons
         * The font dropdown is now fully theme-aware and flawlessly floats over the keyboard
+        * Created a powerful new Custom Filter engine that lets you build your own effects
+        * Added Brightness, Contrast, Saturation, Hue, Temperature, and Tint sliders that can all be layered simultaneously
+        * Fixed OpenGL occlusion bugs so live previews work instantly with custom ColorMatrix filters
         * Replaced awkward placeholder icons with native Discord vectors
         * The editor now instantly boots up with the Pen tool active and ready to draw
         * Smoother animations and ripples

--- a/PhotoEditor/build.gradle.kts
+++ b/PhotoEditor/build.gradle.kts
@@ -18,6 +18,7 @@ aliucord {
         * Moved the Save button to the top header for instant access without scrolling
         * Added a native Discord-style visual overlay for spoilers that hides when you touch the screen
         * Restructured the toolbar to make Undo, Redo, and Reset global actions instead of burying them
+        * Added dynamic state tracking so the Undo, Redo, and Reset buttons automatically grey out when there's nothing to undo
         * Replaced awkward placeholder icons with native Discord vectors
         * The editor now instantly boots up with the Pen tool active and ready to draw
         * Smoother animations and ripples

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/CropOverlayView.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/CropOverlayView.java
@@ -1,0 +1,153 @@
+package com.aliucord.plugins.photoeditor;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.view.MotionEvent;
+
+import com.aliucord.utils.DimenUtils;
+
+public final class CropOverlayView extends android.view.View {
+    private final Paint maskPaint = new Paint();
+    private final Paint borderPaint = new Paint();
+    private final Paint handlePaint = new Paint();
+    private final RectF cropRect = new RectF();
+    private final float handleRadius = DimenUtils.dpToPx(8);
+    private int activeHandle = -1; // 0: TL, 1: TR, 2: BL, 3: BR, 4: Center/Move
+    private float lastX, lastY;
+
+    public CropOverlayView(Context context) {
+        super(context);
+        maskPaint.setColor(0xaa000000); // 66% opacity dark mask
+        maskPaint.setStyle(Paint.Style.FILL);
+
+        borderPaint.setColor(Color.WHITE);
+        borderPaint.setStyle(Paint.Style.STROKE);
+        borderPaint.setStrokeWidth(DimenUtils.dpToPx(2));
+
+        handlePaint.setColor(Color.WHITE);
+        handlePaint.setStyle(Paint.Style.FILL);
+    }
+
+    @Override
+    protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+        super.onSizeChanged(w, h, oldw, oldh);
+        float marginX = w * 0.1f;
+        float marginY = h * 0.1f;
+        cropRect.set(marginX, marginY, w - marginX, h - marginY);
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+        int w = getWidth();
+        int h = getHeight();
+
+        // Draw dark mask outside crop area
+        canvas.drawRect(0, 0, w, cropRect.top, maskPaint);
+        canvas.drawRect(0, cropRect.bottom, w, h, maskPaint);
+        canvas.drawRect(0, cropRect.top, cropRect.left, cropRect.bottom, maskPaint);
+        canvas.drawRect(cropRect.right, cropRect.top, w, cropRect.bottom, maskPaint);
+
+        // Draw crop border
+        canvas.drawRect(cropRect, borderPaint);
+
+        // Draw handles at 4 corners
+        canvas.drawCircle(cropRect.left, cropRect.top, handleRadius, handlePaint);
+        canvas.drawCircle(cropRect.right, cropRect.top, handleRadius, handlePaint);
+        canvas.drawCircle(cropRect.left, cropRect.bottom, handleRadius, handlePaint);
+        canvas.drawCircle(cropRect.right, cropRect.bottom, handleRadius, handlePaint);
+    }
+
+    @Override
+    @SuppressLint("ClickableViewAccessibility")
+    public boolean onTouchEvent(MotionEvent event) {
+        float x = event.getX();
+        float y = event.getY();
+
+        switch (event.getAction()) {
+            case MotionEvent.ACTION_DOWN:
+                lastX = x;
+                lastY = y;
+                activeHandle = getTouchedHandle(x, y);
+                return activeHandle != -1;
+
+            case MotionEvent.ACTION_MOVE:
+                if (activeHandle != -1) {
+                    float dx = x - lastX;
+                    float dy = y - lastY;
+                    moveHandle(activeHandle, dx, dy);
+                    lastX = x;
+                    lastY = y;
+                    invalidate();
+                    return true;
+                }
+                break;
+
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_CANCEL:
+                activeHandle = -1;
+                break;
+        }
+        return super.onTouchEvent(event);
+    }
+
+    private int getTouchedHandle(float x, float y) {
+        float touchTreshold = handleRadius * 2.5f;
+        if (distance(x, y, cropRect.left, cropRect.top) < touchTreshold) return 0; // TL
+        if (distance(x, y, cropRect.right, cropRect.top) < touchTreshold) return 1; // TR
+        if (distance(x, y, cropRect.left, cropRect.bottom) < touchTreshold) return 2; // BL
+        if (distance(x, y, cropRect.right, cropRect.bottom) < touchTreshold) return 3; // BR
+        if (cropRect.contains(x, y)) return 4; // Center
+        return -1;
+    }
+
+    private void moveHandle(int handle, float dx, float dy) {
+        float minSize = handleRadius * 4;
+        int w = getWidth();
+        int h = getHeight();
+
+        if (handle == 4) { // Move whole cropRect
+            if (cropRect.left + dx >= 0 && cropRect.right + dx <= w) {
+                cropRect.left += dx;
+                cropRect.right += dx;
+            }
+            if (cropRect.top + dy >= 0 && cropRect.bottom + dy <= h) {
+                cropRect.top += dy;
+                cropRect.bottom += dy;
+            }
+            return;
+        }
+
+        float newLeft = cropRect.left;
+        float newRight = cropRect.right;
+        float newTop = cropRect.top;
+        float newBottom = cropRect.bottom;
+
+        if (handle == 0 || handle == 2) newLeft = Math.max(0, Math.min(cropRect.right - minSize, cropRect.left + dx));
+        if (handle == 1 || handle == 3) newRight = Math.min(w, Math.max(cropRect.left + minSize, cropRect.right + dx));
+        if (handle == 0 || handle == 1) newTop = Math.max(0, Math.min(cropRect.bottom - minSize, cropRect.top + dy));
+        if (handle == 2 || handle == 3) newBottom = Math.min(h, Math.max(cropRect.top + minSize, cropRect.bottom + dy));
+
+        cropRect.set(newLeft, newTop, newRight, newBottom);
+    }
+
+    private float distance(float x1, float y1, float x2, float y2) {
+        return (float) Math.sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
+    }
+
+    public RectF getCropRectPercent() {
+        int w = getWidth();
+        int h = getHeight();
+        if (w == 0 || h == 0) return new RectF(0.1f, 0.1f, 0.9f, 0.9f);
+        return new RectF(
+                cropRect.left / w,
+                cropRect.top / h,
+                cropRect.right / w,
+                cropRect.bottom / h
+        );
+    }
+}

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/ImagePickerFragment.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/ImagePickerFragment.java
@@ -1,0 +1,42 @@
+package com.aliucord.plugins.photoeditor;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+
+import androidx.fragment.app.Fragment;
+
+public final class ImagePickerFragment extends androidx.fragment.app.Fragment {
+    private OnImagePickedListener listener;
+
+    public void setListener(OnImagePickedListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public void onCreate(android.os.Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        android.content.Intent intent = new android.content.Intent(android.content.Intent.ACTION_GET_CONTENT);
+        intent.setType("image/*");
+        startActivityForResult(intent, 54321);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, android.content.Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == 54321) {
+            if (resultCode == android.app.Activity.RESULT_OK && data != null && data.getData() != null) {
+                if (listener != null) listener.onImagePicked(data.getData());
+            } else {
+                if (listener != null) listener.onImagePicked(null);
+            }
+            listener = null;
+            getParentFragmentManager().beginTransaction().remove(this).commitAllowingStateLoss();
+        }
+    }
+
+    public interface OnImagePickedListener {
+        void onImagePicked(android.net.Uri uri);
+    }
+}

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorColorPicker.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorColorPicker.java
@@ -1,0 +1,255 @@
+package com.aliucord.plugins.photoeditor;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.view.Gravity;
+import android.graphics.Color;
+import android.os.Build;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.aliucord.Utils;
+import com.aliucord.utils.DimenUtils;
+
+import ja.burhanrashid52.photoeditor.PhotoEditor;
+import ja.burhanrashid52.photoeditor.PhotoEditorView;
+
+final class PhotoEditorColorPicker {
+    interface Callback { void onColorPicked(int color); }
+    private PhotoEditorColorPicker() {}
+    private static int dp(int value) { return DimenUtils.dpToPx(value); }
+    private static void addRippleBorderless(View view) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            android.util.TypedValue value = new android.util.TypedValue();
+            view.getContext().getTheme().resolveAttribute(android.R.attr.selectableItemBackgroundBorderless, value, true);
+            view.setBackgroundResource(value.resourceId);
+        }
+    }
+
+    static void show(Context context, PhotoEditorView editorView, PhotoEditor editor, int initialColor, int[] colors, Callback callback) {
+        Dialog dialog = new Dialog(context);
+
+        LinearLayout root = new LinearLayout(context);
+        root.setOrientation(LinearLayout.VERTICAL);
+        root.setPadding(dp(20), dp(20), dp(20), dp(20));
+
+        android.graphics.drawable.GradientDrawable rootBg = new android.graphics.drawable.GradientDrawable();
+        rootBg.setColor(0xff2b2d31);
+        rootBg.setCornerRadius(dp(16));
+        root.setBackground(rootBg);
+
+        // 1. Title Row (Title + Eyedropper)
+        LinearLayout titleRow = new LinearLayout(context);
+        titleRow.setOrientation(LinearLayout.HORIZONTAL);
+        titleRow.setGravity(Gravity.CENTER_VERTICAL);
+
+        TextView title = new TextView(context);
+        title.setText("Custom Color");
+        title.setTextColor(Color.WHITE);
+        title.setTextSize(18f);
+        title.setTypeface(null, android.graphics.Typeface.BOLD);
+        titleRow.addView(title, new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+
+        android.widget.ImageView eyedropper = new android.widget.ImageView(context);
+        int dropperId = Utils.getResId("ic_colorize_24dp", "drawable");
+        if (dropperId == 0) dropperId = Utils.getResId("ic_edit_24dp", "drawable");
+        eyedropper.setImageResource(dropperId);
+        eyedropper.setColorFilter(Color.WHITE);
+        eyedropper.setPadding(dp(8), dp(8), dp(8), dp(8));
+        addRippleBorderless(eyedropper);
+        titleRow.addView(eyedropper);
+        root.addView(titleRow);
+
+        // Eyedropper Logic
+        eyedropper.setOnClickListener(v -> {
+            dialog.dismiss();
+            android.widget.Toast.makeText(context, "Tap anywhere on the image to pick a color!", android.widget.Toast.LENGTH_SHORT).show();
+
+            editor.setBrushDrawingMode(false);
+            editorView.setOnTouchListener(new View.OnTouchListener() {
+                @Override
+                public boolean onTouch(View view, android.view.MotionEvent event) {
+                    int action = event.getAction();
+                    if (action == android.view.MotionEvent.ACTION_DOWN || action == android.view.MotionEvent.ACTION_MOVE || action == android.view.MotionEvent.ACTION_UP || action == android.view.MotionEvent.ACTION_CANCEL) {
+                        try {
+                            android.widget.ImageView source = editorView.getSource();
+                            android.graphics.drawable.BitmapDrawable drawable = (android.graphics.drawable.BitmapDrawable) source.getDrawable();
+                            android.graphics.Bitmap bitmap = drawable.getBitmap();
+
+                            android.graphics.Matrix inverse = new android.graphics.Matrix();
+                            source.getImageMatrix().invert(inverse);
+                            float[] pts = {event.getX(), event.getY()};
+                            inverse.mapPoints(pts);
+
+                            int x = (int) pts[0];
+                            int y = (int) pts[1];
+
+                            if (x >= 0 && y >= 0 && x < bitmap.getWidth() && y < bitmap.getHeight()) {
+                                int pixel = bitmap.getPixel(x, y);
+                                callback.onColorPicked(pixel);
+                            }
+                        } catch (Throwable t) {
+                            // Silently ignore out of bounds during drag
+                        }
+
+                        if (action == android.view.MotionEvent.ACTION_UP || action == android.view.MotionEvent.ACTION_CANCEL) {
+                            editorView.setOnTouchListener(null);
+                            editor.setBrushDrawingMode(true);
+                        }
+                        return true;
+                    }
+                    return false;
+                }
+            });
+        });
+
+        // 2. Preview Box and HEX
+        LinearLayout previewRow = new LinearLayout(context);
+        previewRow.setOrientation(LinearLayout.HORIZONTAL);
+        previewRow.setGravity(Gravity.CENTER_VERTICAL);
+        previewRow.setPadding(0, dp(16), 0, dp(16));
+
+        View previewBox = new View(context);
+        android.graphics.drawable.GradientDrawable boxBg = new android.graphics.drawable.GradientDrawable();
+        boxBg.setCornerRadius(dp(8));
+        boxBg.setColor(initialColor);
+        previewBox.setBackground(boxBg);
+        previewRow.addView(previewBox, new LinearLayout.LayoutParams(dp(48), dp(48)));
+
+        android.widget.EditText hexInput = new android.widget.EditText(context);
+        hexInput.setTextColor(Color.WHITE);
+        hexInput.setText(String.format("#%08X", initialColor));
+        hexInput.setSingleLine(true);
+        LinearLayout.LayoutParams hexParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        hexParams.setMargins(dp(16), 0, 0, 0);
+        previewRow.addView(hexInput, hexParams);
+        root.addView(previewRow);
+
+
+        // 3. HSV Sliders
+        float[] hsv = new float[3];
+        Color.colorToHSV(initialColor, hsv);
+
+        TextView hueLabel = new TextView(context); hueLabel.setText("Hue"); hueLabel.setTextColor(Color.LTGRAY); root.addView(hueLabel);
+        com.google.android.material.slider.Slider hueSlider = PhotoEditorUi.createDiscordSlider(context, 0, 360, hsv[0]); root.addView(hueSlider);
+
+        TextView satLabel = new TextView(context); satLabel.setText("Saturation"); satLabel.setTextColor(Color.LTGRAY); satLabel.setPadding(0, dp(8), 0, 0); root.addView(satLabel);
+        com.google.android.material.slider.Slider satSlider = PhotoEditorUi.createDiscordSlider(context, 0, 100, hsv[1] * 100); root.addView(satSlider);
+
+        TextView valLabel = new TextView(context); valLabel.setText("Lightness"); valLabel.setTextColor(Color.LTGRAY); valLabel.setPadding(0, dp(8), 0, 0); root.addView(valLabel);
+        com.google.android.material.slider.Slider valSlider = PhotoEditorUi.createDiscordSlider(context, 0, 100, hsv[2] * 100); root.addView(valSlider);
+
+        final android.widget.ImageView colorPlane = new android.widget.ImageView(context);
+        int colorPlaneSize = dp(180);
+        colorPlane.setImageBitmap(PhotoEditorUi.createColorPlane(colorPlaneSize));
+        colorPlane.setScaleType(android.widget.ImageView.ScaleType.FIT_XY);
+        root.addView(colorPlane, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, colorPlaneSize));
+        colorPlane.setVisibility(View.GONE);
+        previewBox.setOnClickListener(v -> colorPlane.setVisibility(colorPlane.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE));
+        TextView alphaLabel = new TextView(context); alphaLabel.setText("Opacity"); alphaLabel.setTextColor(Color.LTGRAY); alphaLabel.setPadding(0, dp(8), 0, 0); root.addView(alphaLabel);
+        com.google.android.material.slider.Slider alphaSlider = PhotoEditorUi.createDiscordSlider(context, 0, 255, Color.alpha(initialColor)); root.addView(alphaSlider);
+
+        // 4. Presets Horizontal Scroll
+        android.widget.HorizontalScrollView presetScroll = new android.widget.HorizontalScrollView(context);
+        presetScroll.setHorizontalScrollBarEnabled(false);
+        LinearLayout presetContainer = new LinearLayout(context);
+        presetContainer.setOrientation(LinearLayout.HORIZONTAL);
+        presetContainer.setPadding(0, dp(16), 0, dp(16));
+        for (int c : colors) {
+            View swatch = new View(context);
+            android.graphics.drawable.GradientDrawable swBg = new android.graphics.drawable.GradientDrawable();
+            swBg.setCornerRadius(dp(16)); swBg.setColor(c);
+            swatch.setBackground(swBg);
+            LinearLayout.LayoutParams swParams = new LinearLayout.LayoutParams(dp(32), dp(32));
+            swParams.setMargins(0, 0, dp(8), 0);
+            swatch.setLayoutParams(swParams);
+            swatch.setOnClickListener(v -> {
+                Color.colorToHSV(c, hsv);
+                hueSlider.setValue((int) hsv[0]);
+                satSlider.setValue((int) (hsv[1] * 100));
+                valSlider.setValue((int) (hsv[2] * 100));
+                alphaSlider.setValue(Color.alpha(c));
+            });
+            presetContainer.addView(swatch);
+        }
+        presetScroll.addView(presetContainer);
+        root.addView(presetScroll);
+
+        // Updates
+        final int[] currentColor = {initialColor};
+
+        Runnable updateColor = () -> {
+            try {
+                hsv[0] = hueSlider.getValue();
+                hsv[1] = satSlider.getValue() / 100f;
+                hsv[2] = valSlider.getValue() / 100f;
+                int alpha = Math.round(alphaSlider.getValue());
+                currentColor[0] = Color.HSVToColor(alpha, hsv);
+                boxBg.setColor(currentColor[0]);
+                previewBox.invalidate();
+                if (!hexInput.hasFocus()) {
+                    hexInput.setText(String.format("#%08X", currentColor[0]));
+                }
+            } catch (Exception e) {}
+        };
+
+        colorPlane.setOnTouchListener((v, event) -> {
+            float hue = Math.max(0f, Math.min(360f, event.getX() / Math.max(1f, v.getWidth()) * 360f));
+            float position = Math.max(0f, Math.min(1f, event.getY() / Math.max(1f, v.getHeight())));
+            float saturation = position <= 0.5f ? position * 2f : 1f;
+            float value = position <= 0.5f ? 1f : (1f - position) * 2f;
+            hueSlider.setValue(Math.round(hue));
+            satSlider.setValue(Math.round(saturation * 100f));
+            valSlider.setValue(Math.round(value * 100f));
+            return true;
+        });
+        com.google.android.material.slider.Slider.OnChangeListener sliderListener = (slider, value, fromUser) -> updateColor.run();
+        hueSlider.addOnChangeListener(sliderListener);
+        satSlider.addOnChangeListener(sliderListener);
+        valSlider.addOnChangeListener(sliderListener);
+        alphaSlider.addOnChangeListener(sliderListener);
+        hexInput.addTextChangedListener(new android.text.TextWatcher() {
+            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override public void onTextChanged(CharSequence s, int start, int before, int count) {}
+            @Override public void afterTextChanged(android.text.Editable s) {
+                if (hexInput.hasFocus() && s.toString().startsWith("#")) {
+                    try {
+                        int c = Color.parseColor(s.toString());
+                        currentColor[0] = c;
+                        boxBg.setColor(c);
+                        Color.colorToHSV(c, hsv);
+                        hueSlider.setValue((int) hsv[0]);
+                        satSlider.setValue((int) (hsv[1] * 100));
+                        valSlider.setValue((int) (hsv[2] * 100));
+                        alphaSlider.setValue(Color.alpha(c));
+                    } catch (Exception ignored) {}
+                }
+            }
+        });
+
+        // Buttons
+        LinearLayout btnRow = new LinearLayout(context);
+        btnRow.setOrientation(LinearLayout.HORIZONTAL);
+        btnRow.setGravity(Gravity.RIGHT);
+
+        TextView cancel = new TextView(context); cancel.setText("Cancel"); cancel.setTextColor(Color.GRAY); cancel.setPadding(dp(16), dp(8), dp(16), dp(8));
+        cancel.setOnClickListener(v -> dialog.dismiss());
+        btnRow.addView(cancel);
+
+        TextView apply = new TextView(context); apply.setText("Select"); apply.setTextColor(0xff5865f2); apply.setPadding(dp(16), dp(8), dp(16), dp(8)); apply.setTypeface(null, android.graphics.Typeface.BOLD);
+        apply.setOnClickListener(v -> {
+            callback.onColorPicked(currentColor[0]);
+            dialog.dismiss();
+        });
+        btnRow.addView(apply);
+
+        root.addView(btnRow);
+
+        dialog.setContentView(root);
+        dialog.getWindow().setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(Color.TRANSPARENT));
+        dialog.show();
+    }
+
+}

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorCropDialog.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorCropDialog.java
@@ -1,0 +1,251 @@
+package com.aliucord.plugins.photoeditor;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Color;
+import android.graphics.RectF;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import ja.burhanrashid52.photoeditor.PhotoEditorView;
+
+final class PhotoEditorCropDialog {
+    private PhotoEditorCropDialog() {}
+
+    static void show(PhotoEditorPlugin owner, Context context, android.widget.ImageView targetView, PhotoEditorView editorView) {
+        try {
+            android.graphics.drawable.BitmapDrawable drawable = (android.graphics.drawable.BitmapDrawable) targetView.getDrawable();
+            if (drawable == null) {
+                Toast.makeText(context, "No image to crop", Toast.LENGTH_SHORT).show();
+                return;
+            }
+            Bitmap src = drawable.getBitmap();
+            if (src == null) {
+                Toast.makeText(context, "No bitmap to crop", Toast.LENGTH_SHORT).show();
+                return;
+            }
+
+            LinearLayout layout = new LinearLayout(context);
+            layout.setOrientation(LinearLayout.VERTICAL);
+
+            TextView info = new TextView(context);
+            info.setText("Drag corners to resize. Drag center to move crop area:");
+            info.setTextColor(Color.parseColor("#dbdee1"));
+            info.setTextSize(12f);
+            info.setPadding(0, 0, 0, owner.dp(12));
+            layout.addView(info);
+
+            float[] rotation = {0f};
+            boolean[] flip = {false, false};
+
+            // Create downscaled base for smooth preview dragging
+            int maxDim = Math.max(src.getWidth(), src.getHeight());
+            float downscale = maxDim > 800 ? 800f / maxDim : 1f;
+            Bitmap previewBase = downscale == 1f ? src : Bitmap.createScaledBitmap(src, (int)(src.getWidth() * downscale), (int)(src.getHeight() * downscale), true);
+
+            Bitmap[] currentPreview = {previewBase};
+
+            // Container for image and crop overlay
+            FrameLayout container = new FrameLayout(context) {
+                @Override
+                protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+                    int width = View.MeasureSpec.getSize(widthMeasureSpec);
+                    int height = (int) (width * ((float) currentPreview[0].getHeight() / currentPreview[0].getWidth()));
+                    int maxHeight = owner.dp(350);
+                    if (height > maxHeight) {
+                        height = maxHeight;
+                        width = (int) (height * ((float) currentPreview[0].getWidth() / currentPreview[0].getHeight()));
+                    }
+                    int wSpec = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY);
+                    int hSpec = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY);
+                    super.onMeasure(wSpec, hSpec);
+                }
+            };
+            LinearLayout.LayoutParams containerParams = new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            );
+            containerParams.setMargins(0, 0, 0, owner.dp(16));
+            containerParams.gravity = Gravity.CENTER_HORIZONTAL;
+            container.setLayoutParams(containerParams);
+
+            android.widget.ImageView previewImage = new android.widget.ImageView(context);
+            previewImage.setImageBitmap(currentPreview[0]);
+            previewImage.setScaleType(android.widget.ImageView.ScaleType.FIT_XY);
+            container.addView(previewImage, new FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+            ));
+
+            CropOverlayView cropOverlay = new CropOverlayView(context);
+            container.addView(cropOverlay, new FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+            ));
+
+            layout.addView(container);
+
+            Runnable updatePreview = () -> {
+                android.graphics.Matrix m = new android.graphics.Matrix();
+                m.postRotate(rotation[0]);
+                if (flip[0]) m.postScale(-1, 1);
+                if (flip[1]) m.postScale(1, -1);
+                if (currentPreview[0] != null && currentPreview[0] != previewBase) {
+                    currentPreview[0].recycle();
+                }
+                currentPreview[0] = Bitmap.createBitmap(previewBase, 0, 0, previewBase.getWidth(), previewBase.getHeight(), m, true);
+                previewImage.setImageBitmap(currentPreview[0]);
+                container.requestLayout();
+            };
+
+            // Rotation Controls
+            LinearLayout rotateControls = new LinearLayout(context);
+            rotateControls.setOrientation(LinearLayout.VERTICAL);
+            rotateControls.setPadding(0, owner.dp(8), 0, owner.dp(16));
+
+            LinearLayout sliderRow = new LinearLayout(context);
+            sliderRow.setOrientation(LinearLayout.HORIZONTAL);
+            sliderRow.setGravity(Gravity.CENTER_VERTICAL);
+
+            TextView degreeLabel = new TextView(context);
+            degreeLabel.setText("0°");
+            degreeLabel.setTextColor(Color.WHITE);
+            degreeLabel.setMinWidth(owner.dp(40));
+            degreeLabel.setGravity(Gravity.CENTER);
+            sliderRow.addView(degreeLabel);
+
+            com.google.android.material.slider.Slider rotateSlider = PhotoEditorUi.createDiscordSlider(context, 0, 360, 180);
+            rotateSlider.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+            rotateSlider.addOnChangeListener((slider, value, fromUser) -> {
+                if (fromUser) {
+                    rotation[0] = value - 180f;
+                    degreeLabel.setText((int) rotation[0] + "°");
+                    updatePreview.run();
+                }
+            });
+            sliderRow.addView(rotateSlider);
+            rotateControls.addView(sliderRow);
+
+            LinearLayout mirrorRow = new LinearLayout(context);
+            mirrorRow.setOrientation(LinearLayout.HORIZONTAL);
+            mirrorRow.setGravity(Gravity.CENTER);
+            mirrorRow.setPadding(0, owner.dp(8), 0, 0);
+
+            View flipHBtn = owner.iconButton(context, "Flip H", "ic_swap_horiz_24dp", v -> {
+                flip[0] = !flip[0];
+                updatePreview.run();
+            });
+            mirrorRow.addView(flipHBtn);
+
+            View flipVBtn = owner.iconButton(context, "Flip V", "ic_swap_vert_24dp", v -> {
+                flip[1] = !flip[1];
+                updatePreview.run();
+            });
+            mirrorRow.addView(flipVBtn);
+
+            View rotate90Btn = owner.iconButton(context, "Rotate 90°", "ucrop_ic_rotate", v -> {
+                float newRot = rotation[0] + 90f;
+                if (newRot > 180f) newRot -= 360f;
+                rotation[0] = newRot;
+                rotateSlider.setValue((int)newRot + 180);
+                degreeLabel.setText((int)newRot + "°");
+                updatePreview.run();
+            });
+            mirrorRow.addView(rotate90Btn);
+
+            rotateControls.addView(mirrorRow);
+            layout.addView(rotateControls);
+
+            Dialog dialog[] = new Dialog[1];
+
+            LinearLayout buttons = new LinearLayout(context);
+            buttons.setOrientation(LinearLayout.HORIZONTAL);
+            buttons.setGravity(Gravity.RIGHT);
+
+            TextView cancelBtn = new TextView(context);
+            cancelBtn.setText("Cancel");
+            cancelBtn.setTextColor(Color.parseColor("#dbdee1"));
+            cancelBtn.setPadding(owner.dp(16), owner.dp(10), owner.dp(16), owner.dp(10));
+            cancelBtn.setOnClickListener(v -> dialog[0].dismiss());
+            buttons.addView(cancelBtn);
+
+            TextView applyBtn = new TextView(context);
+            applyBtn.setText("Crop");
+            applyBtn.setTextColor(Color.WHITE);
+            applyBtn.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
+            applyBtn.setPadding(owner.dp(16), owner.dp(10), owner.dp(16), owner.dp(10));
+
+            android.graphics.drawable.GradientDrawable applyBg = new android.graphics.drawable.GradientDrawable();
+            applyBg.setColor(0xff5865f2);
+            applyBg.setCornerRadius(owner.dp(6));
+            applyBtn.setBackground(applyBg);
+
+            applyBtn.setOnClickListener(v -> {
+                try {
+                    // 1. Generate full-res rotated bitmap
+                    android.graphics.Matrix m = new android.graphics.Matrix();
+                    m.postRotate(rotation[0]);
+                    if (flip[0]) m.postScale(-1, 1);
+                    if (flip[1]) m.postScale(1, -1);
+                    Bitmap finalRotatedSrc = (rotation[0] == 0f && !flip[0] && !flip[1]) ? src : Bitmap.createBitmap(src, 0, 0, src.getWidth(), src.getHeight(), m, true);
+
+                    RectF percent = cropOverlay.getCropRectPercent();
+                    int w = finalRotatedSrc.getWidth();
+                    int h = finalRotatedSrc.getHeight();
+
+                    int left = (int) (w * percent.left);
+                    int top = (int) (h * percent.top);
+                    int right = (int) (w * percent.right);
+                    int bottom = (int) (h * percent.bottom);
+
+                    int cropWidth = right - left;
+                    int cropHeight = bottom - top;
+
+                    if (cropWidth > 10 && cropHeight > 10) {
+                        Bitmap cropped = Bitmap.createBitmap(finalRotatedSrc, left, top, cropWidth, cropHeight);
+                        if (finalRotatedSrc != src) {
+                            finalRotatedSrc.recycle();
+                        }
+                        targetView.setScaleType(android.widget.ImageView.ScaleType.FIT_XY);
+                        targetView.setImageBitmap(cropped);
+
+                        if (targetView == editorView.getSource()) {
+                            owner.fillEditorBaseLayers(editorView);
+                            if (editorView.getParent() instanceof View)
+                                owner.fitEditorToBitmap(editorView, (View) editorView.getParent(), cropped);
+                        } else {
+                            targetView.requestLayout();
+                        }
+                        Toast.makeText(context, "Cropped successfully", Toast.LENGTH_SHORT).show();
+                    }
+                } catch (Throwable e) {
+                    owner.logError(e);
+                    Toast.makeText(context, "Crop failed: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                }
+                dialog[0].dismiss();
+            });
+
+            LinearLayout.LayoutParams applyParams = new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            );
+            applyParams.setMargins(owner.dp(8), 0, 0, 0);
+            applyBtn.setLayoutParams(applyParams);
+            buttons.addView(applyBtn);
+
+            layout.addView(buttons);
+
+            dialog[0] = owner.customDialog(context, "Crop Image", layout);
+            dialog[0].show();
+        } catch (Throwable t) {
+            owner.logError("Failed to show crop dialog", t);
+        }
+    }
+
+}

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorFilterDialog.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorFilterDialog.java
@@ -1,0 +1,139 @@
+package com.aliucord.plugins.photoeditor;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.drawable.ColorDrawable;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.aliucord.api.SettingsAPI;
+import com.aliucord.utils.DimenUtils;
+
+import ja.burhanrashid52.photoeditor.PhotoEditorView;
+
+final class PhotoEditorFilterDialog {
+    private PhotoEditorFilterDialog() {}
+    private static int dp(int value) { return DimenUtils.dpToPx(value); }
+    private static LinearLayout createContainer(Context context) {
+        LinearLayout layout = new LinearLayout(context);
+        layout.setOrientation(LinearLayout.VERTICAL);
+        layout.setPadding(dp(20), dp(20), dp(20), dp(20));
+        layout.setBackgroundColor(0xff313338);
+        return layout;
+    }
+
+    static void show(Context context, PhotoEditorView editorView, com.aliucord.api.SettingsAPI settings, float[] customFilterValues) {
+        Dialog dialog = new Dialog(context);
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+
+        LinearLayout layout = createContainer(context);
+        android.widget.ScrollView scrollContent = new android.widget.ScrollView(context);
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+
+        Runnable updateFilter = () -> {
+            for (int i=0; i<editorView.getChildCount(); i++) {
+                android.view.View child = editorView.getChildAt(i);
+                if (child.getClass().getName().contains("ImageFilterView")) {
+                    child.setVisibility(android.view.View.GONE);
+                }
+            }
+            float[] matrix = PhotoEditorUtils.buildCustomMatrix(customFilterValues);
+            boolean applyToEverything = settings.getInt("filter_apply_mode", 0) == 1;
+            if (applyToEverything) {
+                Paint p = new Paint();
+                p.setColorFilter(new android.graphics.ColorMatrixColorFilter(matrix));
+                editorView.setLayerType(android.view.View.LAYER_TYPE_HARDWARE, p);
+                editorView.getSource().clearColorFilter();
+            } else {
+                editorView.setLayerType(android.view.View.LAYER_TYPE_NONE, null);
+                editorView.getSource().setColorFilter(new android.graphics.ColorMatrixColorFilter(matrix));
+            }
+        };
+
+        String[] labels = {"Brightness", "Contrast", "Saturation", "Hue", "Temperature", "Tint"};
+        float[] mins = {-100f, 0f, 0f, -180f, -50f, -50f};
+        float[] maxs = {100f, 2f, 2f, 180f, 50f, 50f};
+        float[] defaults = {0f, 1f, 1f, 0f, 0f, 0f};
+
+        for (int i = 0; i < 6; i++) {
+            final int index = i;
+            LinearLayout row = new LinearLayout(context);
+            row.setOrientation(LinearLayout.VERTICAL);
+            row.setPadding(0, 0, 0, dp(16));
+
+            LinearLayout header = new LinearLayout(context);
+            header.setOrientation(LinearLayout.HORIZONTAL);
+
+            TextView label = new TextView(context);
+            label.setText(labels[i]);
+            label.setTextColor(Color.WHITE);
+            label.setTextSize(14f);
+
+            TextView valueText = new TextView(context);
+            valueText.setText(String.format(java.util.Locale.US, "%.2f", customFilterValues[i]));
+            valueText.setTextColor(Color.GRAY);
+            valueText.setTextSize(12f);
+
+            LinearLayout.LayoutParams lblParams = new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
+            header.addView(label, lblParams);
+            header.addView(valueText);
+
+            row.addView(header);
+
+            com.google.android.material.slider.Slider slider = PhotoEditorUi.createDiscordSlider(context, 0, 200, 0);
+
+            float current = customFilterValues[i];
+            float range = maxs[i] - mins[i];
+            int progress = (int) (((current - mins[i]) / range) * 200f);
+            slider.setValue(progress);
+
+            slider.addOnChangeListener((view, value, fromUser) -> {
+                if (fromUser) {
+                    float val = mins[index] + (value / 200f) * range;
+                    customFilterValues[index] = val;
+                    valueText.setText(String.format(java.util.Locale.US, "%.2f", val));
+                    updateFilter.run();
+                }
+            });
+            row.addView(slider);
+            content.addView(row);
+        }
+
+        TextView resetBtn = new TextView(context);
+        resetBtn.setText("Reset Custom Filter");
+        resetBtn.setTextColor(0xffda373c);
+        resetBtn.setTextSize(14f);
+        resetBtn.setGravity(Gravity.CENTER);
+        resetBtn.setPadding(dp(16), dp(16), dp(16), dp(16));
+        resetBtn.setOnClickListener(v -> {
+            System.arraycopy(defaults, 0, customFilterValues, 0, defaults.length);
+            updateFilter.run();
+            dialog.dismiss();
+            show(context, editorView, settings, customFilterValues); // Reopen to refresh sliders
+        });
+        content.addView(resetBtn);
+
+        scrollContent.addView(content);
+        layout.addView(scrollContent, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                dp(300)
+        ));
+
+        dialog.setContentView(layout);
+        Window window = dialog.getWindow();
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+            window.setGravity(Gravity.BOTTOM);
+            window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        }
+        dialog.show();
+    }
+
+}

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorHeader.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorHeader.java
@@ -1,0 +1,127 @@
+package com.aliucord.plugins.photoeditor;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.os.Build;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.aliucord.Utils;
+import com.lytefast.flexinput.model.Attachment;
+import com.lytefast.flexinput.utils.SelectionAggregator;
+
+final class PhotoEditorHeader {
+    private PhotoEditorHeader() {}
+
+    static View create(PhotoEditorPlugin owner, Context context, Attachment<?>[] currentAttachment, SelectionAggregator<?> aggregator, View.OnClickListener onClose, PhotoEditorPlugin.SpoilerToggleListener spoilerListener) {
+        LinearLayout header = new LinearLayout(context);
+        header.setOrientation(LinearLayout.HORIZONTAL);
+        header.setGravity(Gravity.CENTER_VERTICAL);
+        header.setBackgroundColor(0xff1e1f22);
+        header.setPadding(owner.dp(16), owner.dp(10), owner.dp(16), owner.dp(10));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            header.setElevation(owner.dp(4));
+        }
+
+        android.widget.ImageView closeBtn = new android.widget.ImageView(context);
+        int closeId = Utils.getResId("ic_close_24dp", "drawable");
+        closeBtn.setImageResource(closeId != 0 ? closeId : android.R.drawable.ic_menu_close_clear_cancel);
+        closeBtn.setColorFilter(Color.WHITE);
+        closeBtn.setPadding(owner.dp(8), owner.dp(8), owner.dp(8), owner.dp(8));
+        closeBtn.setOnClickListener(onClose);
+        owner.addRippleBorderless(closeBtn);
+        owner.addPressAnimation(closeBtn);
+
+        LinearLayout.LayoutParams closeParams = new LinearLayout.LayoutParams(owner.dp(40), owner.dp(40));
+        closeParams.setMargins(0, 0, owner.dp(8), 0);
+        closeBtn.setLayoutParams(closeParams);
+        header.addView(closeBtn);
+
+        TextView title = new TextView(context);
+        String displayName = currentAttachment[0].getDisplayName();
+        title.setText(displayName == null ? "PhotoEditor" : displayName);
+        title.setTextColor(Color.WHITE);
+        title.setTextSize(16f);
+        title.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
+        title.setSingleLine(true);
+        title.setEllipsize(android.text.TextUtils.TruncateAt.END);
+        LinearLayout.LayoutParams titleParams = new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
+        title.setLayoutParams(titleParams);
+        header.addView(title);
+
+        if (aggregator != null) {
+            // Spoiler toggle
+            android.widget.ImageView spoilerBtn = new android.widget.ImageView(context);
+            int eyeOpenId = Utils.getResId("ic_eye_24dp", "drawable");
+            int eyeClosedId = Utils.getResId("ic_eye_closed_24dp", "drawable");
+            if (eyeOpenId == 0) eyeOpenId = android.R.drawable.ic_menu_view;
+            if (eyeClosedId == 0) eyeClosedId = android.R.drawable.ic_menu_view;
+
+            boolean[] isSpoiler = {currentAttachment[0].getSpoiler()};
+            spoilerBtn.setImageResource(isSpoiler[0] ? eyeClosedId : eyeOpenId);
+            spoilerBtn.setColorFilter(isSpoiler[0] ? 0xffda373c : Color.WHITE);
+            spoilerBtn.setPadding(owner.dp(8), owner.dp(8), owner.dp(8), owner.dp(8));
+            owner.addRippleBorderless(spoilerBtn);
+            owner.addPressAnimation(spoilerBtn);
+
+            final int finalEyeOpen = eyeOpenId;
+            final int finalEyeClosed = eyeClosedId;
+
+            spoilerBtn.setOnClickListener(v -> {
+                isSpoiler[0] = !isSpoiler[0];
+                spoilerBtn.setImageResource(isSpoiler[0] ? finalEyeClosed : finalEyeOpen);
+                spoilerBtn.setColorFilter(isSpoiler[0] ? 0xffda373c : Color.WHITE);
+
+                try {
+                    Attachment<?> edited = new Attachment<>(
+                            currentAttachment[0].getId(),
+                            currentAttachment[0].getUri(),
+                            currentAttachment[0].getDisplayName(),
+                            null,
+                            isSpoiler[0]
+                    );
+                    owner.replaceAttachment(aggregator, currentAttachment[0], edited);
+                    currentAttachment[0] = edited;
+                    if (spoilerListener != null) {
+                        spoilerListener.onSpoilerToggled(isSpoiler[0]);
+                    }
+                } catch (Throwable t) {
+                    owner.logError("Failed to toggle spoiler", t);
+                }
+            });
+
+            LinearLayout.LayoutParams spoilerParams = new LinearLayout.LayoutParams(owner.dp(40), owner.dp(40));
+            spoilerParams.setMargins(0, 0, owner.dp(8), 0);
+            header.addView(spoilerBtn, spoilerParams);
+
+            // Delete button
+            android.widget.ImageView deleteBtn = new android.widget.ImageView(context);
+            int deleteId = Utils.getResId("ic_delete_24dp", "drawable");
+            deleteBtn.setImageResource(deleteId != 0 ? deleteId : android.R.drawable.ic_menu_delete);
+            deleteBtn.setColorFilter(0xffda373c);
+            deleteBtn.setPadding(owner.dp(8), owner.dp(8), owner.dp(8), owner.dp(8));
+            owner.addRippleBorderless(deleteBtn);
+            owner.addPressAnimation(deleteBtn);
+
+            deleteBtn.setOnClickListener(v -> {
+                try {
+                    java.lang.reflect.Method remove = SelectionAggregator.class.getDeclaredMethod("removeItem", Attachment.class);
+                    remove.setAccessible(true);
+                    remove.invoke(aggregator, currentAttachment[0]);
+                    onClose.onClick(v);
+                } catch (Throwable t) {
+                    owner.logError("Failed to delete attachment", t);
+                }
+            });
+
+            LinearLayout.LayoutParams deleteParams = new LinearLayout.LayoutParams(owner.dp(40), owner.dp(40));
+            header.addView(deleteBtn, deleteParams);
+        }
+
+        return header;
+    }
+
+}

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorImagePicker.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorImagePicker.java
@@ -1,0 +1,42 @@
+package com.aliucord.plugins.photoeditor;
+
+import android.content.Context;
+import android.widget.Toast;
+
+import com.aliucord.Utils;
+
+import ja.burhanrashid52.photoeditor.PhotoEditor;
+import ja.burhanrashid52.photoeditor.PhotoEditorView;
+
+final class PhotoEditorImagePicker {
+    private PhotoEditorImagePicker() {}
+
+    static void show(PhotoEditorPlugin owner, Context context, PhotoEditor editor, PhotoEditorView editorView) {
+        androidx.fragment.app.FragmentActivity activity = owner.findFragmentActivity(context);
+        if (activity == null) activity = owner.findFragmentActivity(Utils.getAppActivity());
+        if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
+            android.widget.Toast.makeText(context, "Could not open image picker", android.widget.Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        ImagePickerFragment fragment = new ImagePickerFragment();
+        fragment.setListener(uri -> {
+            if (uri != null) {
+                com.aliucord.Utils.threadPool.execute(() -> {
+                    try {
+                        android.graphics.Bitmap bmp = android.provider.MediaStore.Images.Media.getBitmap(context.getContentResolver(), uri);
+                        if (bmp != null) {
+                            com.aliucord.Utils.mainThread.post(() -> owner.addBitmapOverlay(editorView, bmp));
+                        }
+                    } catch (Throwable t) {
+                        owner.logError("Failed to load picked image", t);
+                        com.aliucord.Utils.mainThread.post(() -> android.widget.Toast.makeText(context, "Failed to load image", android.widget.Toast.LENGTH_SHORT).show());
+                    }
+                });
+            }
+        });
+
+        activity.getSupportFragmentManager().beginTransaction().add(fragment, "IMAGE_PICKER").commitAllowingStateLoss();
+    }
+
+}

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorOverlayDialogs.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorOverlayDialogs.java
@@ -1,0 +1,259 @@
+package com.aliucord.plugins.photoeditor;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.graphics.Color;
+import android.os.Build;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ja.burhanrashid52.photoeditor.PhotoEditorView;
+
+final class PhotoEditorOverlayDialogs {
+    private PhotoEditorOverlayDialogs() {}
+
+    static void showOptions(PhotoEditorPlugin owner, Context context, View viewToRemove, android.view.ViewGroup parent) {
+        android.app.Dialog dialog = new android.app.Dialog(context);
+        dialog.requestWindowFeature(android.view.Window.FEATURE_NO_TITLE);
+
+        android.widget.LinearLayout layout = new android.widget.LinearLayout(context);
+        layout.setOrientation(android.widget.LinearLayout.VERTICAL);
+        layout.setPadding(owner.dp(24), owner.dp(24), owner.dp(24), owner.dp(24));
+
+        android.graphics.drawable.GradientDrawable bg = new android.graphics.drawable.GradientDrawable();
+        bg.setColor(0xff313338);
+        bg.setCornerRadius(owner.dp(16));
+        layout.setBackground(bg);
+
+        android.widget.TextView title = new android.widget.TextView(context);
+        title.setText("Overlay Options");
+        title.setTextColor(android.graphics.Color.WHITE);
+        title.setTextSize(20f);
+        title.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
+        title.setPadding(0, 0, 0, owner.dp(12));
+
+        android.widget.TextView message = new android.widget.TextView(context);
+        message.setText("What would you like to do with this item?");
+        message.setTextColor(android.graphics.Color.parseColor("#dbdee1"));
+        message.setTextSize(16f);
+        message.setPadding(0, 0, 0, owner.dp(24));
+
+        android.widget.LinearLayout buttons = new android.widget.LinearLayout(context);
+        buttons.setOrientation(android.widget.LinearLayout.HORIZONTAL);
+        buttons.setGravity(android.view.Gravity.END);
+        buttons.setPadding(0, owner.dp(8), 0, 0);
+
+        android.widget.TextView cancel = new android.widget.TextView(context);
+        cancel.setText("Cancel");
+        cancel.setTextColor(android.graphics.Color.WHITE);
+        cancel.setTextSize(14f);
+        cancel.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
+        cancel.setPadding(owner.dp(20), owner.dp(10), owner.dp(20), owner.dp(10));
+        cancel.setOnClickListener(v -> dialog.dismiss());
+        buttons.addView(cancel);
+
+        if (viewToRemove instanceof android.widget.ImageView) {
+            android.widget.ImageView iv = (android.widget.ImageView) viewToRemove;
+            if (iv.getDrawable() instanceof android.graphics.drawable.BitmapDrawable) {
+                android.widget.TextView crop = new android.widget.TextView(context);
+                crop.setText("Crop");
+                crop.setTextColor(android.graphics.Color.WHITE);
+                crop.setTextSize(14f);
+                crop.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
+                crop.setPadding(owner.dp(24), owner.dp(10), owner.dp(24), owner.dp(10));
+
+                android.graphics.drawable.GradientDrawable cropBg = new android.graphics.drawable.GradientDrawable();
+                cropBg.setColor(0xff5865f2);
+                cropBg.setCornerRadius(owner.dp(6));
+                crop.setBackground(cropBg);
+
+                android.widget.LinearLayout.LayoutParams cropParams = new android.widget.LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                );
+                cropParams.setMargins(owner.dp(8), 0, owner.dp(8), 0);
+                crop.setLayoutParams(cropParams);
+
+                crop.setOnClickListener(v -> {
+                    dialog.dismiss();
+                    PhotoEditorCropDialog.show(owner, context, iv, (PhotoEditorView) parent);
+                });
+                buttons.addView(crop);
+            }
+        }
+
+        android.widget.TextView delete = new android.widget.TextView(context);
+        delete.setText("Delete");
+        delete.setTextColor(android.graphics.Color.WHITE);
+        delete.setTextSize(14f);
+        delete.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
+        delete.setPadding(owner.dp(24), owner.dp(10), owner.dp(24), owner.dp(10));
+
+        android.graphics.drawable.GradientDrawable deleteBg = new android.graphics.drawable.GradientDrawable();
+        deleteBg.setColor(0xffda373c);
+        deleteBg.setCornerRadius(owner.dp(6));
+        delete.setBackground(deleteBg);
+
+        android.widget.LinearLayout.LayoutParams delParams = new android.widget.LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        delParams.setMargins(owner.dp(8), 0, 0, 0);
+        delete.setLayoutParams(delParams);
+
+        delete.setOnClickListener(v -> {
+            parent.removeView(viewToRemove);
+            dialog.dismiss();
+        });
+        buttons.addView(delete);
+
+        layout.addView(title);
+        layout.addView(message);
+        layout.addView(buttons);
+
+        dialog.setContentView(layout);
+        android.view.Window win = dialog.getWindow();
+        if (win != null) {
+            win.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT));
+            win.setLayout((int) (android.content.res.Resources.getSystem().getDisplayMetrics().widthPixels * 0.9f), android.view.ViewGroup.LayoutParams.WRAP_CONTENT);
+        }
+        dialog.show();
+    }
+
+
+    static void showTextEditor(PhotoEditorPlugin owner, Context context, TextView target) {
+        Dialog dialog = new Dialog(context);
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+
+        LinearLayout layout = owner.createBottomSheetContainer(context, "Edit Text");
+        EditText input = owner.dialogInput(context, "Enter your text...");
+        input.setText(target.getText());
+        input.setSelectAllOnFocus(false);
+        input.setSelection(input.getText().length());
+
+        android.graphics.drawable.GradientDrawable inputBg = new android.graphics.drawable.GradientDrawable();
+        inputBg.setColor(0xff1e1f22);
+        inputBg.setCornerRadius(owner.dp(8));
+        inputBg.setStroke(owner.dp(1), Color.parseColor("#3f4147"));
+        input.setBackground(inputBg);
+        input.setTextColor(Color.WHITE);
+        input.setHintTextColor(Color.parseColor("#80848e"));
+        input.setTextSize(16f);
+        input.setMinLines(2);
+        input.setGravity(Gravity.TOP | Gravity.START);
+        input.setPadding(owner.dp(12), owner.dp(12), owner.dp(12), owner.dp(12));
+        LinearLayout.LayoutParams inputParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        inputParams.setMargins(0, 0, 0, owner.dp(16));
+        layout.addView(input, inputParams);
+
+        final int[] chosenColor = {target.getCurrentTextColor()};
+        TextView colorLabel = new TextView(context);
+        colorLabel.setText("Color");
+        colorLabel.setTextColor(Color.parseColor("#b5bac1"));
+        colorLabel.setTextSize(12f);
+        colorLabel.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
+        colorLabel.setPadding(0, 0, 0, owner.dp(8));
+        layout.addView(colorLabel);
+
+        LinearLayout colorRow = new LinearLayout(context);
+        colorRow.setOrientation(LinearLayout.HORIZONTAL);
+        colorRow.setGravity(Gravity.CENTER_VERTICAL);
+        List<View> swatches = new ArrayList<>();
+        for (int color : PhotoEditorPlugin.COLORS) {
+            View swatch = owner.colorSwatch(context, color, view -> {
+                chosenColor[0] = color;
+                owner.selectColorOnly(swatches, color);
+            });
+            swatch.setTag(color);
+            swatches.add(swatch);
+            colorRow.addView(swatch);
+        }
+        owner.selectColorOnly(swatches, chosenColor[0]);
+        LinearLayout.LayoutParams colorParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        colorParams.setMargins(0, 0, 0, owner.dp(18));
+        layout.addView(colorRow, colorParams);
+
+        LinearLayout buttons = new LinearLayout(context);
+        buttons.setOrientation(LinearLayout.HORIZONTAL);
+        buttons.setGravity(Gravity.RIGHT);
+
+        TextView deleteBtn = dialogButton(owner, context, "Delete", Color.parseColor("#f23f42"), false);
+        deleteBtn.setOnClickListener(v -> {
+            ViewGroup parent = (ViewGroup) target.getParent();
+            if (parent != null)
+                parent.removeView(target);
+            dialog.dismiss();
+        });
+        buttons.addView(deleteBtn);
+
+        TextView cancelBtn = dialogButton(owner, context, "Cancel", Color.parseColor("#dbdee1"), false);
+        cancelBtn.setOnClickListener(v -> dialog.dismiss());
+        buttons.addView(cancelBtn);
+
+        TextView saveBtn = dialogButton(owner, context, "Save", Color.WHITE, true);
+        saveBtn.setOnClickListener(v -> {
+            String text = input.getText().toString().trim();
+            if (!text.isEmpty()) {
+                target.setText(text);
+                target.setTextColor(chosenColor[0]);
+                target.requestLayout();
+            }
+            dialog.dismiss();
+        });
+        LinearLayout.LayoutParams saveParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        saveParams.setMargins(owner.dp(8), 0, 0, 0);
+        saveBtn.setLayoutParams(saveParams);
+        buttons.addView(saveBtn);
+
+        layout.addView(buttons);
+        owner.showKeyboardDialog(dialog, layout, input);
+    }
+
+
+    private static TextView dialogButton(PhotoEditorPlugin owner, Context context, String text, int color, boolean primary) {
+        TextView button = new TextView(context);
+        button.setText(text);
+        button.setTextColor(color);
+        button.setTextSize(14f);
+        button.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
+        button.setGravity(Gravity.CENTER);
+        button.setPadding(owner.dp(14), owner.dp(10), owner.dp(14), owner.dp(10));
+
+        android.graphics.drawable.GradientDrawable bg = new android.graphics.drawable.GradientDrawable();
+        if (primary) {
+            bg.setColor(0xff5865f2);
+        } else {
+            bg.setColor(Color.TRANSPARENT);
+        }
+        bg.setCornerRadius(owner.dp(8));
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            android.content.res.ColorStateList rippleColor = android.content.res.ColorStateList.valueOf(0x40ffffff);
+            android.graphics.drawable.RippleDrawable ripple = new android.graphics.drawable.RippleDrawable(rippleColor, bg, null);
+            button.setBackground(ripple);
+        } else {
+            button.setBackground(bg);
+        }
+
+        owner.addPressAnimation(button);
+        return button;
+    }
+
+}

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorOverlayTouchListener.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorOverlayTouchListener.java
@@ -1,0 +1,103 @@
+package com.aliucord.plugins.photoeditor;
+
+import android.view.MotionEvent;
+import android.view.View;
+
+    final class PhotoEditorOverlayTouchListener implements View.OnTouchListener {
+        private final PhotoEditorPlugin owner;
+        private final View parent;
+        private float downRawX;
+        private float downRawY;
+        private float startX;
+        private float startY;
+        private float startDistance;
+        private float startScale;
+        private long downTime;
+        private boolean moved;
+        private int mode;
+        private Runnable longClickRunnable;
+
+        PhotoEditorOverlayTouchListener(PhotoEditorPlugin owner, View parent) {
+            this.owner = owner;
+            this.parent = parent;
+        }
+
+        @Override
+        public boolean onTouch(View view, MotionEvent event) {
+            switch (event.getActionMasked()) {
+                case MotionEvent.ACTION_DOWN:
+                    view.bringToFront();
+                    downRawX = event.getRawX();
+                    downRawY = event.getRawY();
+                    startX = view.getX();
+                    startY = view.getY();
+                    downTime = System.currentTimeMillis();
+                    moved = false;
+                    mode = 0;
+
+                    if (longClickRunnable != null) view.removeCallbacks(longClickRunnable);
+                    longClickRunnable = () -> {
+                        if (!moved) {
+                            PhotoEditorOverlayDialogs.showOptions(owner,view.getContext(), view, (android.view.ViewGroup) parent);
+                        }
+                    };
+                    view.postDelayed(longClickRunnable, 500);
+                    return true;
+                case MotionEvent.ACTION_POINTER_DOWN:
+                    if (longClickRunnable != null) view.removeCallbacks(longClickRunnable);
+                    if (event.getPointerCount() == 2) {
+                        startDistance = pointerDistance(event);
+                        startScale = view.getScaleX();
+                        mode = 1;
+                    }
+                    return true;
+                case MotionEvent.ACTION_MOVE:
+                    if (mode == 1 && event.getPointerCount() >= 2) {
+                        float newDist = pointerDistance(event);
+                        if (newDist > 10f) {
+                            float scale = (newDist / startDistance) * startScale;
+                            view.setScaleX(Math.max(0.1f, scale));
+                            view.setScaleY(Math.max(0.1f, scale));
+                        }
+                    } else if (mode == 0) {
+                        float deltaX = event.getRawX() - downRawX;
+                        float deltaY = event.getRawY() - downRawY;
+                        if (Math.abs(deltaX) > owner.dp(4) || Math.abs(deltaY) > owner.dp(4)) {
+                            moved = true;
+                            if (longClickRunnable != null) view.removeCallbacks(longClickRunnable);
+                        }
+                        float nextX = startX + deltaX;
+                        float nextY = startY + deltaY;
+                        float maxX = Math.max(0, parent.getWidth() - view.getWidth());
+                        float maxY = Math.max(0, parent.getHeight() - view.getHeight());
+                        view.setX(Math.max(0, Math.min(maxX, nextX)));
+                        view.setY(Math.max(0, Math.min(maxY, nextY)));
+                    }
+                    return true;
+                case MotionEvent.ACTION_POINTER_UP:
+                    if (event.getPointerCount() <= 2)
+                        mode = 1;
+                    return true;
+                case MotionEvent.ACTION_UP:
+                    if (longClickRunnable != null) view.removeCallbacks(longClickRunnable);
+                    if (!moved && System.currentTimeMillis() - downTime < 350 && PhotoEditorPlugin.OVERLAY_TEXT.equals(view.getTag()) && view instanceof android.widget.TextView)
+                        PhotoEditorOverlayDialogs.showTextEditor(owner,view.getContext(), (android.widget.TextView) view);
+                    mode = 0;
+                    return true;
+                case MotionEvent.ACTION_CANCEL:
+                    if (longClickRunnable != null) view.removeCallbacks(longClickRunnable);
+                    mode = 0;
+                    return true;
+                default:
+                    return true;
+            }
+        }
+
+        private float pointerDistance(MotionEvent event) {
+            if (event.getPointerCount() < 2)
+                return 0f;
+            float dx = event.getX(0) - event.getX(1);
+            float dy = event.getY(0) - event.getY(1);
+            return (float) Math.sqrt(dx * dx + dy * dy);
+        }
+    }

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -121,7 +121,7 @@ public class PhotoEditorPlugin extends Plugin {
         
         rootContainer.addView(subToolbarContainer, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
-                dp(52)
+                dp(64)
         ));
         rootContainer.addView(mainScroll, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -87,76 +87,105 @@ import kotlin.Unit;
 @AliucordPlugin
 @SuppressWarnings("unused")
 public class PhotoEditorPlugin extends Plugin {
-    private View createToolbar(Context context, PhotoEditor editor, PhotoEditorView editorView, Dialog dialog, Attachment<?> attachment, EditRequest editRequest) {
-        android.widget.HorizontalScrollView scrollView = new android.widget.HorizontalScrollView(context);
-        scrollView.setHorizontalScrollBarEnabled(false);
-        scrollView.setBackgroundColor(0xff1e1f22);
 
-        LinearLayout toolbar = new LinearLayout(context);
-        toolbar.setOrientation(LinearLayout.HORIZONTAL);
-        toolbar.setGravity(Gravity.CENTER_VERTICAL);
-        toolbar.setPadding(dp(8), dp(7), dp(8), dp(7));
-        scrollView.addView(toolbar, new android.widget.HorizontalScrollView.LayoutParams(
+    public interface SpoilerToggleListener {
+        void onSpoilerToggled(boolean isSpoiler);
+    }
+
+    private View createToolbar(Context context, PhotoEditor editor, PhotoEditorView editorView, Dialog dialog, Attachment<?> attachment, EditRequest editRequest) {
+        LinearLayout rootContainer = new LinearLayout(context);
+        rootContainer.setOrientation(LinearLayout.VERTICAL);
+        rootContainer.setBackgroundColor(0xff1e1f22);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            rootContainer.setElevation(dp(8));
+        }
+
+        FrameLayout subToolbarContainer = new FrameLayout(context);
+        subToolbarContainer.setBackgroundColor(0xff2b2d31);
+        subToolbarContainer.setVisibility(View.GONE);
+        rootContainer.addView(subToolbarContainer, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        android.widget.HorizontalScrollView mainScroll = new android.widget.HorizontalScrollView(context);
+        mainScroll.setHorizontalScrollBarEnabled(false);
+
+        LinearLayout mainToolbar = new LinearLayout(context);
+        mainToolbar.setOrientation(LinearLayout.HORIZONTAL);
+        mainToolbar.setGravity(Gravity.CENTER_VERTICAL);
+        mainToolbar.setPadding(dp(8), dp(7), dp(8), dp(7));
+        mainScroll.addView(mainToolbar, new android.widget.HorizontalScrollView.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        rootContainer.addView(mainScroll, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        List<View> mainButtons = new ArrayList<>();
+        List<View> toolButtons = new ArrayList<>();
+        List<View> sizeButtons = new ArrayList<>();
+        List<View> colorSwatches = new ArrayList<>();
+        List<View> filterButtons = new ArrayList<>();
+
+        PhotoFilter[] sessionFilter = {PhotoFilter.NONE};
+
+        // --- DRAW SUB-TOOLBAR ---
+        android.widget.HorizontalScrollView drawScroll = new android.widget.HorizontalScrollView(context);
+        drawScroll.setHorizontalScrollBarEnabled(false);
+        LinearLayout drawToolbar = new LinearLayout(context);
+        drawToolbar.setOrientation(LinearLayout.HORIZONTAL);
+        drawToolbar.setGravity(Gravity.CENTER_VERTICAL);
+        drawToolbar.setPadding(dp(8), dp(7), dp(8), dp(7));
+        drawScroll.addView(drawToolbar, new android.widget.HorizontalScrollView.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
         ));
 
-        List<View> toolButtons = new ArrayList<>();
-        List<View> sizeButtons = new ArrayList<>();
-        List<View> colorSwatches = new ArrayList<>();
-
-        // Per-session filter — avoids stale class-field state across editor openings
-        PhotoFilter[] sessionFilter = {PhotoFilter.NONE};
-
-        View drawButton = iconButton(context, "Draw", "ic_edit_24dp", null);
-        drawButton.setOnClickListener(view -> {
-            selectOnly(toolButtons, drawButton);
+        View penButton = iconButton(context, "Pen", "ic_edit_24dp", null);
+        penButton.setOnClickListener(v -> {
+            selectOnly(toolButtons, penButton);
             editor.setBrushDrawingMode(true);
             applyBrush(editor);
         });
-        toolButtons.add(drawButton);
-        toolbar.addView(drawButton);
+        toolButtons.add(penButton);
+        drawToolbar.addView(penButton);
 
         View eraseButton = iconButton(context, "Erase", "ic_delete_24dp", null);
-        eraseButton.setOnClickListener(view -> {
+        eraseButton.setOnClickListener(v -> {
             selectOnly(toolButtons, eraseButton);
             editor.setBrushDrawingMode(true);
             editor.brushEraser();
         });
         toolButtons.add(eraseButton);
-        toolbar.addView(eraseButton);
+        drawToolbar.addView(eraseButton);
 
-        toolbar.addView(iconButton(context, "Text", "ic_text_channel_white_24dp", view -> showTextDialog(context, editor, editorView)));
-        toolbar.addView(iconButton(context, "Emoji", "ic_emoji_24dp", view -> showDiscordEmojiPicker(context, editor, editorView)));
-        toolbar.addView(iconButton(context, "Sticker", "ic_sticker_icon_24dp", view -> showDiscordStickerPicker(context, editor, editorView)));
-        toolbar.addView(iconButton(context, "Image", "ic_photo_grey_24dp", view -> showImagePicker(context, editor, editorView)));
-        toolbar.addView(iconButton(context, "Crop", "ucrop_ic_crop", view -> showCropDialog(context, editorView)));
-        toolbar.addView(iconButton(context, "Filter", "ic_filter_list_grey_24dp", view -> showFilterDialog(context, editor, sessionFilter)));
-
-        toolbar.addView(groupSeparator(context));
+        drawToolbar.addView(groupSeparator(context));
 
         View thinButton = iconButton(context, "S", null, null);
-        thinButton.setOnClickListener(view -> {
+        thinButton.setOnClickListener(v -> {
             selectOnly(sizeButtons, thinButton);
             brushSize = 12;
             applyBrush(editor);
         });
         sizeButtons.add(thinButton);
-        toolbar.addView(thinButton);
+        drawToolbar.addView(thinButton);
 
         View thickButton = iconButton(context, "L", null, null);
-        thickButton.setOnClickListener(view -> {
+        thickButton.setOnClickListener(v -> {
             selectOnly(sizeButtons, thickButton);
             brushSize = 42;
             applyBrush(editor);
         });
         sizeButtons.add(thickButton);
-        toolbar.addView(thickButton);
+        drawToolbar.addView(thickButton);
 
-        toolbar.addView(groupSeparator(context));
+        drawToolbar.addView(groupSeparator(context));
 
         for (int color : COLORS) {
-            View swatch = colorSwatch(context, color, view -> {
+            View swatch = colorSwatch(context, color, v -> {
                 brushColor = color;
                 textColor = color;
                 selectColorOnly(colorSwatches, color);
@@ -165,12 +194,11 @@ public class PhotoEditorPlugin extends Plugin {
             });
             swatch.setTag(color);
             colorSwatches.add(swatch);
-            toolbar.addView(swatch);
+            drawToolbar.addView(swatch);
         }
 
-        toolbar.addView(groupSeparator(context));
-
-        toolbar.addView(iconButton(context, "Undo", "material_ic_keyboard_arrow_left_black_24dp", view -> {
+        drawToolbar.addView(groupSeparator(context));
+        drawToolbar.addView(iconButton(context, "Undo", "material_ic_keyboard_arrow_left_black_24dp", v -> {
             boolean undidOverlay = false;
             for (int i = editorView.getChildCount() - 1; i >= 0; i--) {
                 View child = editorView.getChildAt(i);
@@ -181,22 +209,99 @@ public class PhotoEditorPlugin extends Plugin {
                     break;
                 }
             }
-            if (!undidOverlay) {
-                editor.undo();
-            }
+            if (!undidOverlay) editor.undo();
         }));
-        toolbar.addView(iconButton(context, "Redo", "material_ic_keyboard_arrow_right_black_24dp", view -> editor.redo()));
-        toolbar.addView(iconButton(context, "Clear", "ic_close_24dp", view -> clearAllEditorOverlays(editor, editorView)));
+        drawToolbar.addView(iconButton(context, "Redo", "material_ic_keyboard_arrow_right_black_24dp", v -> editor.redo()));
+        drawToolbar.addView(iconButton(context, "Clear", "ic_close_24dp", v -> clearAllEditorOverlays(editor, editorView)));
 
-        toolbar.addView(groupSeparator(context));
+        // --- FILTER SUB-TOOLBAR ---
+        android.widget.HorizontalScrollView filterScroll = new android.widget.HorizontalScrollView(context);
+        filterScroll.setHorizontalScrollBarEnabled(false);
+        LinearLayout filterToolbar = new LinearLayout(context);
+        filterToolbar.setOrientation(LinearLayout.HORIZONTAL);
+        filterToolbar.setGravity(Gravity.CENTER_VERTICAL);
+        filterToolbar.setPadding(dp(8), dp(7), dp(8), dp(7));
+        filterScroll.addView(filterToolbar, new android.widget.HorizontalScrollView.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
 
-        toolbar.addView(iconButton(context, "Save", "ic_check_circle_24dp", view -> saveImage(context, editor, editorView, attachment, editRequest, dialog, sessionFilter)));
+        for (PhotoFilter filter : FILTERS) {
+            View fBtn = iconButton(context, humanize(filter.name()), null, null);
+            fBtn.setTag(filter);
+            filterButtons.add(fBtn);
+            fBtn.setOnClickListener(v -> {
+                selectOnly(filterButtons, fBtn);
+                sessionFilter[0] = filter;
+                selectedFilter = filter;
+                editor.setFilterEffect(filter);
+                boolean isGlOnly = isGlOnlyFilter(filter);
+                boolean cantSaveGl = isGlOnly && android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N;
+                if (cantSaveGl)
+                    Toast.makeText(context, "This filter requires Android 7.0+ to save properly", Toast.LENGTH_LONG).show();
+            });
+            filterToolbar.addView(fBtn);
+        }
 
-        setToolbarButtonSelected(drawButton, true);
+        // --- MAIN TOOLBAR ---
+        View drawMainBtn = iconButton(context, "Draw", "ic_edit_24dp", null);
+        drawMainBtn.setOnClickListener(v -> {
+            selectOnly(mainButtons, drawMainBtn);
+            subToolbarContainer.removeAllViews();
+            subToolbarContainer.addView(drawScroll);
+            subToolbarContainer.setVisibility(View.VISIBLE);
+            selectOnly(toolButtons, penButton);
+            editor.setBrushDrawingMode(true);
+            applyBrush(editor);
+        });
+        mainButtons.add(drawMainBtn);
+        mainToolbar.addView(drawMainBtn);
+
+        View textMainBtn = iconButton(context, "Text", "ic_text_channel_white_24dp", v -> showTextDialog(context, editor, editorView));
+        mainToolbar.addView(textMainBtn);
+
+        View emojiMainBtn = iconButton(context, "Emoji", "ic_emoji_24dp", v -> showDiscordEmojiPicker(context, editor, editorView));
+        mainToolbar.addView(emojiMainBtn);
+
+        View stickerMainBtn = iconButton(context, "Sticker", "ic_sticker_icon_24dp", v -> showDiscordStickerPicker(context, editor, editorView));
+        mainToolbar.addView(stickerMainBtn);
+
+        View imageMainBtn = iconButton(context, "Image", "ic_photo_grey_24dp", v -> showImagePicker(context, editor, editorView));
+        mainToolbar.addView(imageMainBtn);
+
+        View cropMainBtn = iconButton(context, "Crop", "ucrop_ic_crop", v -> showCropDialog(context, editorView));
+        mainToolbar.addView(cropMainBtn);
+
+        View filterMainBtn = iconButton(context, "Filter", "ic_filter_list_grey_24dp", null);
+        filterMainBtn.setOnClickListener(v -> {
+            selectOnly(mainButtons, filterMainBtn);
+            subToolbarContainer.removeAllViews();
+            subToolbarContainer.addView(filterScroll);
+            subToolbarContainer.setVisibility(View.VISIBLE);
+            editor.setBrushDrawingMode(false);
+            for (int i=0; i<filterButtons.size(); i++) {
+                if (filterButtons.get(i).getTag() == sessionFilter[0]) {
+                    selectOnly(filterButtons, filterButtons.get(i));
+                    break;
+                }
+            }
+        });
+        mainButtons.add(filterMainBtn);
+        mainToolbar.addView(filterMainBtn);
+
+        mainToolbar.addView(groupSeparator(context));
+        View saveBtn = iconButton(context, "Save", "ic_check_circle_24dp", v -> saveImage(context, editor, editorView, attachment, editRequest, dialog, sessionFilter));
+        mainToolbar.addView(saveBtn);
+
+        // Initial state
+        setToolbarButtonSelected(drawMainBtn, true);
+        subToolbarContainer.addView(drawScroll);
+        subToolbarContainer.setVisibility(View.VISIBLE);
+        setToolbarButtonSelected(penButton, true);
         setToolbarButtonSelected(brushSize <= 12 ? thinButton : thickButton, true);
         selectColorOnly(colorSwatches, brushColor);
 
-        return scrollView;
+        return rootContainer;
     }
 
     private static final String OVERLAY_TEXT = "photoeditor:text";
@@ -260,7 +365,23 @@ public class PhotoEditorPlugin extends Plugin {
                         SelectionAggregator.class,
                         Attachment.class
                 ),
-                new PreHook(callFrame -> registerEditRequest((SelectionAggregator<?>) callFrame.args[0], (Attachment<?>) callFrame.args[1]))
+                new InsteadHook(callFrame -> {
+                    SelectionAggregator<?> aggregator = (SelectionAggregator<?>) callFrame.args[0];
+                    Attachment<?> attachment = (Attachment<?>) callFrame.args[1];
+                    registerEditRequest(aggregator, attachment);
+
+                    FragmentActivity activity = findFragmentActivity(com.aliucord.Utils.getAppActivity());
+                    if (activity != null && isLikelyImage(attachment)) {
+                        com.aliucord.Utils.mainThread.post(() -> openEditor(activity, attachment, editRequests.get(attachment), aggregator));
+                        return null;
+                    }
+                    try {
+                        return XposedBridge.invokeOriginalMethod(callFrame.method, callFrame.thisObject, callFrame.args);
+                    } catch (Throwable t) {
+                        logger.error(t);
+                        return null;
+                    }
+                })
         );
 
         patcher.patch(
@@ -273,18 +394,51 @@ public class PhotoEditorPlugin extends Plugin {
                 new Hook(callFrame -> latestChatInputAttachments = new WeakReference<>((WidgetChatInputAttachments) callFrame.thisObject))
         );
 
-        patcher.patch(
-                StickerPickerViewModel.class.getDeclaredMethod("onStickerSelected", Sticker.class),
-                new InsteadHook(callFrame -> {
-                    if (editorStickerPickerOpen)
-                        return true;
-                    try {
-                        return XposedBridge.invokeOriginalMethod(callFrame.method, callFrame.thisObject, callFrame.args);
-                    } catch (Throwable throwable) {
-                        throw new RuntimeException(throwable);
+        for (java.lang.reflect.Method method : StickerPickerViewModel.class.getDeclaredMethods()) {
+            Class<?>[] paramTypes = method.getParameterTypes();
+            if (paramTypes.length >= 1 && (paramTypes[0] == Sticker.class || paramTypes[0] == Object.class)) {
+                Class<?> retType = method.getReturnType();
+                if (retType == boolean.class || retType == Boolean.class || retType == void.class) {
+                    patcher.patch(method, new InsteadHook(callFrame -> {
+                        if (editorStickerPickerOpen) {
+                            if (retType == boolean.class || retType == Boolean.class) return true;
+                            return null;
+                        }
+                        try {
+                            return XposedBridge.invokeOriginalMethod(callFrame.method, callFrame.thisObject, callFrame.args);
+                        } catch (Throwable throwable) {
+                            throw new RuntimeException(throwable);
+                        }
+                    }));
+                }
+            }
+        }
+
+        try {
+            java.lang.reflect.Field fMessageManager = StickerPickerViewModel.class.getDeclaredField("messageManager");
+            Class<?> messageManagerClass = fMessageManager.getType();
+
+            if (messageManagerClass != null) {
+                for (java.lang.reflect.Method method : messageManagerClass.getDeclaredMethods()) {
+                    Class<?> mRetType = method.getReturnType();
+                    if ((mRetType == void.class || mRetType == boolean.class || mRetType == Boolean.class) && method.getParameterTypes().length > 5 && method.getName().contains("sendMessage")) {
+                        patcher.patch(method, new InsteadHook(callFrame -> {
+                            if (editorStickerPickerOpen) {
+                                if (mRetType == boolean.class || mRetType == Boolean.class) return false;
+                                return null; // for god sake.
+                            }
+                            try {
+                                return XposedBridge.invokeOriginalMethod(callFrame.method, callFrame.thisObject, callFrame.args);
+                            } catch (Throwable throwable) {
+                                throw new RuntimeException(throwable);
+                            }
+                        }));
                     }
-                })
-        );
+                }
+            }
+        } catch (Throwable t) {
+            logger.error("Failed to hook MessageManager", t);
+        }
 
         patcher.patch(
                 WidgetChatListAdapterItemAttachment.class.getDeclaredMethod("onConfigure", int.class, ChatListEntry.class),
@@ -418,7 +572,7 @@ public class PhotoEditorPlugin extends Plugin {
                         null,
                         false
                 );
-                Utils.mainThread.post(() -> openEditor(finalActivity, attachment, edited -> addEditedReplyAttachment(finalActivity, sentImageContext.message, edited)));
+                Utils.mainThread.post(() -> openEditor(finalActivity, attachment, edited -> addEditedReplyAttachment(finalActivity, sentImageContext.message, edited), null));
             } catch (Throwable throwable) {
                 logger.error("Failed to download sent image for editing", throwable);
                 Utils.mainThread.post(() -> Toast.makeText(context, "Failed to load image for editing", Toast.LENGTH_SHORT).show());
@@ -505,7 +659,7 @@ public class PhotoEditorPlugin extends Plugin {
             edit.setOnClickListener(view -> {
                 FragmentActivity activity = findFragmentActivity(view.getContext());
                 sheet.dismiss();
-                Utils.mainThread.postDelayed(() -> openEditor(activity, attachment, editRequest), 160);
+                Utils.mainThread.postDelayed(() -> openEditor(activity, attachment, editRequest, null), 160);
             });
 
             ConstraintLayout.LayoutParams params = new ConstraintLayout.LayoutParams(
@@ -532,19 +686,21 @@ public class PhotoEditorPlugin extends Plugin {
         return remove != null && remove.getParent() instanceof ViewGroup ? (ViewGroup) remove.getParent() : null;
     }
 
-    private void openEditor(Activity activity, Attachment<?> attachment, EditRequest editRequest) {
-        if (activity == null || activity.isFinishing() || (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && activity.isDestroyed())) {
-            Toast.makeText(Utils.getAppActivity(), "Could not open image editor", Toast.LENGTH_SHORT).show();
+    private void openEditor(Activity passedActivity, Attachment<?> attachment, EditRequest editRequest, SelectionAggregator<?> aggregator) {
+        Activity activity = com.aliucord.Utils.getAppActivity();
+        if (activity == null) {
+            activity = passedActivity;
+        }
+        if (activity == null) {
+            android.widget.Toast.makeText(com.aliucord.Utils.getAppActivity(), "Could not open image editor (activity null)", android.widget.Toast.LENGTH_SHORT).show();
             return;
         }
         if (attachment.getUri() == null) {
-            Toast.makeText(activity, "Attachment has no URI", Toast.LENGTH_SHORT).show();
+            android.widget.Toast.makeText(activity, "Attachment has no URI", android.widget.Toast.LENGTH_SHORT).show();
             return;
         }
 
-
-        Dialog dialog = new Dialog(activity);
-        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+        Dialog dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar_Fullscreen);
 
         PhotoEditorView editorView = new PhotoEditorView(activity);
         PhotoEditor editor = new PhotoEditor.Builder(activity, editorView)
@@ -552,7 +708,42 @@ public class PhotoEditorPlugin extends Plugin {
                 .setClipSourceImage(false)
                 .build();
 
-        FrameLayout root = new FrameLayout(activity);
+        FrameLayout spoilerOverlay = new FrameLayout(activity);
+        spoilerOverlay.setBackgroundColor(0x99000000);
+        
+        TextView spoilerText = new TextView(activity);
+        spoilerText.setText("SPOILER");
+        spoilerText.setTextColor(Color.WHITE);
+        spoilerText.setTextSize(24f);
+        spoilerText.setTypeface(null, android.graphics.Typeface.BOLD);
+        spoilerText.setPadding(dp(20), dp(8), dp(20), dp(8));
+        
+        android.graphics.drawable.GradientDrawable pill = new android.graphics.drawable.GradientDrawable();
+        pill.setColor(0x80000000);
+        pill.setCornerRadius(dp(20));
+        spoilerText.setBackground(pill);
+        
+        spoilerOverlay.addView(spoilerText, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                Gravity.CENTER
+        ));
+        spoilerOverlay.setVisibility(attachment.getSpoiler() ? View.VISIBLE : View.GONE);
+
+        FrameLayout root = new FrameLayout(activity) {
+            @Override
+            public boolean dispatchTouchEvent(android.view.MotionEvent ev) {
+                if (ev.getAction() == android.view.MotionEvent.ACTION_DOWN) {
+                    if (spoilerOverlay.getVisibility() == View.VISIBLE && spoilerOverlay.getAlpha() == 1f) {
+                        spoilerOverlay.animate().alpha(0f).setDuration(150).withEndAction(() -> {
+                            spoilerOverlay.setVisibility(View.GONE);
+                            spoilerOverlay.setAlpha(1f);
+                        }).start();
+                    }
+                }
+                return super.dispatchTouchEvent(ev);
+            }
+        };
         root.setBackgroundColor(0xff111214);
 
         LinearLayout content = new LinearLayout(activity);
@@ -562,7 +753,20 @@ public class PhotoEditorPlugin extends Plugin {
                 ViewGroup.LayoutParams.MATCH_PARENT
         ));
 
-        View header = createHeader(activity, attachment.getDisplayName(), view -> dialog.dismiss());
+        View header = createHeader(activity, attachment, aggregator, view -> dialog.dismiss(), isSpoiler -> {
+            if (isSpoiler) {
+                spoilerOverlay.setVisibility(View.VISIBLE);
+                spoilerOverlay.setAlpha(0f);
+                spoilerOverlay.animate().alpha(1f).setDuration(150).setListener(null).start();
+            } else {
+                if (spoilerOverlay.getVisibility() == View.VISIBLE) {
+                    spoilerOverlay.animate().alpha(0f).setDuration(150).withEndAction(() -> {
+                        spoilerOverlay.setVisibility(View.GONE);
+                        spoilerOverlay.setAlpha(1f);
+                    }).start();
+                }
+            }
+        });
         content.addView(header, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
@@ -580,6 +784,11 @@ public class PhotoEditorPlugin extends Plugin {
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 Gravity.CENTER
+        ));
+
+        editorHolder.addView(spoilerOverlay, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
         ));
 
         ProgressBar progressBar = new ProgressBar(activity);
@@ -608,6 +817,11 @@ public class PhotoEditorPlugin extends Plugin {
             loadImage(attachment.getUri(), editorView, editorHolder, progressBar);
             applyBrush(editor);
         });
+        dialog.setOnDismissListener(ignored -> {
+            editorStickerPickerOpen = false;
+        });
+
+        editorStickerPickerOpen = true;
         try {
             dialog.show();
         } catch (android.view.WindowManager.BadTokenException badTokenException) {
@@ -616,23 +830,24 @@ public class PhotoEditorPlugin extends Plugin {
         }
     }
 
-    private View createHeader(Context context, String displayName, View.OnClickListener onClose) {
+    private View createHeader(Context context, Attachment<?> attachment, SelectionAggregator<?> aggregator, View.OnClickListener onClose, SpoilerToggleListener spoilerListener) {
         LinearLayout header = new LinearLayout(context);
         header.setOrientation(LinearLayout.HORIZONTAL);
         header.setGravity(Gravity.CENTER_VERTICAL);
         header.setBackgroundColor(0xff1e1f22);
         header.setPadding(dp(16), dp(10), dp(16), dp(10));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            header.setElevation(dp(4));
+        }
 
         android.widget.ImageView closeBtn = new android.widget.ImageView(context);
         int closeId = Utils.getResId("ic_close_24dp", "drawable");
-        if (closeId != 0) {
-            closeBtn.setImageResource(closeId);
-        } else {
-            closeBtn.setImageResource(android.R.drawable.ic_menu_close_clear_cancel);
-        }
+        closeBtn.setImageResource(closeId != 0 ? closeId : android.R.drawable.ic_menu_close_clear_cancel);
         closeBtn.setColorFilter(Color.WHITE);
         closeBtn.setPadding(dp(8), dp(8), dp(8), dp(8));
         closeBtn.setOnClickListener(onClose);
+        addRippleBorderless(closeBtn);
+        addPressAnimation(closeBtn);
 
         LinearLayout.LayoutParams closeParams = new LinearLayout.LayoutParams(dp(40), dp(40));
         closeParams.setMargins(0, 0, dp(8), 0);
@@ -640,6 +855,7 @@ public class PhotoEditorPlugin extends Plugin {
         header.addView(closeBtn);
 
         TextView title = new TextView(context);
+        String displayName = attachment.getDisplayName();
         title.setText(displayName == null ? "PhotoEditor" : displayName);
         title.setTextColor(Color.WHITE);
         title.setTextSize(16f);
@@ -649,6 +865,74 @@ public class PhotoEditorPlugin extends Plugin {
         LinearLayout.LayoutParams titleParams = new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
         title.setLayoutParams(titleParams);
         header.addView(title);
+
+        if (aggregator != null) {
+            // Spoiler toggle
+            android.widget.ImageView spoilerBtn = new android.widget.ImageView(context);
+            int eyeOpenId = Utils.getResId("ic_eye_24dp", "drawable");
+            int eyeClosedId = Utils.getResId("ic_eye_closed_24dp", "drawable");
+            if (eyeOpenId == 0) eyeOpenId = android.R.drawable.ic_menu_view;
+            if (eyeClosedId == 0) eyeClosedId = android.R.drawable.ic_menu_view;
+
+            boolean[] isSpoiler = {attachment.getSpoiler()};
+            spoilerBtn.setImageResource(isSpoiler[0] ? eyeClosedId : eyeOpenId);
+            spoilerBtn.setColorFilter(isSpoiler[0] ? 0xffda373c : Color.WHITE);
+            spoilerBtn.setPadding(dp(8), dp(8), dp(8), dp(8));
+            addRippleBorderless(spoilerBtn);
+            addPressAnimation(spoilerBtn);
+            
+            final int finalEyeOpen = eyeOpenId;
+            final int finalEyeClosed = eyeClosedId;
+
+            spoilerBtn.setOnClickListener(v -> {
+                isSpoiler[0] = !isSpoiler[0];
+                spoilerBtn.setImageResource(isSpoiler[0] ? finalEyeClosed : finalEyeOpen);
+                spoilerBtn.setColorFilter(isSpoiler[0] ? 0xffda373c : Color.WHITE);
+                
+                try {
+                    Attachment<?> edited = new Attachment<>(
+                            attachment.getId(),
+                            attachment.getUri(),
+                            attachment.getDisplayName(),
+                            null,
+                            isSpoiler[0]
+                    );
+                    replaceAttachment(aggregator, attachment, edited);
+                    if (spoilerListener != null) {
+                        spoilerListener.onSpoilerToggled(isSpoiler[0]);
+                    }
+                } catch (Throwable t) {
+                    logger.error("Failed to toggle spoiler", t);
+                }
+            });
+
+            LinearLayout.LayoutParams spoilerParams = new LinearLayout.LayoutParams(dp(40), dp(40));
+            spoilerParams.setMargins(0, 0, dp(8), 0);
+            header.addView(spoilerBtn, spoilerParams);
+
+            // Delete button
+            android.widget.ImageView deleteBtn = new android.widget.ImageView(context);
+            int deleteId = Utils.getResId("ic_delete_24dp", "drawable");
+            deleteBtn.setImageResource(deleteId != 0 ? deleteId : android.R.drawable.ic_menu_delete);
+            deleteBtn.setColorFilter(0xffda373c);
+            deleteBtn.setPadding(dp(8), dp(8), dp(8), dp(8));
+            addRippleBorderless(deleteBtn);
+            addPressAnimation(deleteBtn);
+
+            deleteBtn.setOnClickListener(v -> {
+                try {
+                    java.lang.reflect.Method remove = SelectionAggregator.class.getDeclaredMethod("removeItem", Attachment.class);
+                    remove.setAccessible(true);
+                    remove.invoke(aggregator, attachment);
+                    onClose.onClick(v);
+                } catch (Throwable t) {
+                    logger.error("Failed to delete attachment", t);
+                }
+            });
+
+            LinearLayout.LayoutParams deleteParams = new LinearLayout.LayoutParams(dp(40), dp(40));
+            header.addView(deleteBtn, deleteParams);
+        }
 
         return header;
     }
@@ -672,13 +956,15 @@ public class PhotoEditorPlugin extends Plugin {
         container.setOrientation(LinearLayout.VERTICAL);
         container.setGravity(Gravity.CENTER);
         container.setPadding(dp(8), dp(8), dp(8), dp(8));
-        container.setMinimumWidth(dp(38));
-        container.setMinimumHeight(dp(42));
+        container.setMinimumWidth(dp(48));
+        container.setMinimumHeight(dp(48));
         container.setContentDescription(label);
 
         setToolbarButtonSelected(container, false);
         if (listener != null)
             container.setOnClickListener(listener);
+
+        addPressAnimation(container);
 
         LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT,
@@ -714,20 +1000,26 @@ public class PhotoEditorPlugin extends Plugin {
         View swatch = new View(context);
         setColorSwatchSelected(swatch, color, color == brushColor);
         swatch.setOnClickListener(listener);
+        addPressAnimation(swatch);
 
-        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(dp(24), dp(24));
-        params.setMargins(0, 0, dp(6), 0);
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(dp(32), dp(32));
+        params.setMargins(0, 0, dp(8), 0);
         swatch.setLayoutParams(params);
         return swatch;
     }
 
     private void setToolbarButtonSelected(View button, boolean selected) {
         android.graphics.drawable.GradientDrawable bg = new android.graphics.drawable.GradientDrawable();
-        bg.setColor(selected ? 0xff5865f2 : 0xff2b2d31);
-        bg.setCornerRadius(dp(8));
-        if (selected)
-            bg.setStroke(dp(1), 0xff9aa6ff);
-        button.setBackground(bg);
+        bg.setColor(selected ? 0xcc5865f2 : 0x00000000);
+        bg.setCornerRadius(dp(12));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            android.content.res.ColorStateList rippleColor = android.content.res.ColorStateList.valueOf(0x40ffffff);
+            android.graphics.drawable.RippleDrawable ripple = new android.graphics.drawable.RippleDrawable(rippleColor, bg, null);
+            button.setBackground(ripple);
+        } else {
+            button.setBackground(bg);
+        }
+
 
         if (button instanceof ViewGroup) {
             ViewGroup group = (ViewGroup) button;
@@ -745,8 +1037,15 @@ public class PhotoEditorPlugin extends Plugin {
         android.graphics.drawable.GradientDrawable drawable = new android.graphics.drawable.GradientDrawable();
         drawable.setShape(android.graphics.drawable.GradientDrawable.OVAL);
         drawable.setColor(color);
-        drawable.setStroke(dp(selected ? 3 : 2), selected ? Color.WHITE : Color.parseColor("#4e5058"));
-        swatch.setBackground(drawable);
+        drawable.setStroke(dp(selected ? 3 : 1), selected ? Color.WHITE : Color.parseColor("#4e5058"));
+        
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            android.content.res.ColorStateList rippleColor = android.content.res.ColorStateList.valueOf(0x40ffffff);
+            android.graphics.drawable.RippleDrawable ripple = new android.graphics.drawable.RippleDrawable(rippleColor, drawable, null);
+            swatch.setBackground(ripple);
+        } else {
+            swatch.setBackground(drawable);
+        }
     }
 
     private void selectOnly(List<View> buttons, View selected) {
@@ -800,6 +1099,8 @@ public class PhotoEditorPlugin extends Plugin {
         if (window != null) {
             window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
             window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+            window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
+            window.setDimAmount(0.6f);
         }
         return dialog;
     }
@@ -831,58 +1132,7 @@ public class PhotoEditorPlugin extends Plugin {
         activity.getSupportFragmentManager().beginTransaction().add(fragment, "IMAGE_PICKER").commitAllowingStateLoss();
     }
 
-    private void showFilterDialog(Context context, PhotoEditor editor, PhotoFilter[] sessionFilter) {
-        LinearLayout list = new LinearLayout(context);
-        list.setOrientation(LinearLayout.VERTICAL);
-
-        Dialog dialog[] = new Dialog[1];
-
-        android.widget.ScrollView scrollView = new android.widget.ScrollView(context);
-        scrollView.setLayoutParams(new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                dp(250)
-        ));
-        scrollView.addView(list);
-
-        for (int i = 0; i < FILTERS.length; i++) {
-            PhotoFilter filter = FILTERS[i];
-            TextView item = new TextView(context);
-            String label = humanize(filter.name());
-            boolean isGlOnly = isGlOnlyFilter(filter);
-            boolean cantSaveGl = isGlOnly && android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N;
-            item.setText(cantSaveGl ? label + " (preview only)" : label);
-            item.setTextColor(Color.parseColor(cantSaveGl ? "#80848e" : "#dbdee1"));
-            item.setTextSize(14f);
-            item.setPadding(dp(12), dp(12), dp(12), dp(12));
-
-            android.graphics.drawable.GradientDrawable itemBg = new android.graphics.drawable.GradientDrawable();
-            itemBg.setColor(filter == sessionFilter[0] ? 0xff5865f2 : 0xff2b2d31);
-            itemBg.setCornerRadius(dp(6));
-            if (filter == sessionFilter[0])
-                itemBg.setStroke(dp(1), 0xff9aa6ff);
-            item.setBackground(itemBg);
-
-            LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT
-            );
-            params.setMargins(0, 0, 0, dp(8));
-            item.setLayoutParams(params);
-
-            item.setOnClickListener(v -> {
-                sessionFilter[0] = filter;
-                selectedFilter = filter; // keep class field in sync for any legacy callers
-                editor.setFilterEffect(filter);
-                if (dialog[0] != null) dialog[0].dismiss();
-                if (cantSaveGl)
-                    Toast.makeText(context, "This filter requires Android 7.0+ to save properly", Toast.LENGTH_LONG).show();
-            });
-            list.addView(item);
-        }
-
-        dialog[0] = customDialog(context, "Select Filter", scrollView);
-        dialog[0].show();
-    }
+    // showFilterDialog removed because it is now rendered inline within the toolbar
 
     /** Returns true for filters that rely purely on GL shaders and have no ColorMatrix equivalent. */
     private boolean isGlOnlyFilter(PhotoFilter filter) {
@@ -1077,6 +1327,8 @@ public class PhotoEditorPlugin extends Plugin {
             window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
             window.setGravity(Gravity.TOP | Gravity.CENTER_HORIZONTAL);
             window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+            window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
+            window.setDimAmount(0.6f);
             window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE | WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
         }
         dialog.setOnShowListener(ignored -> {
@@ -1147,7 +1399,6 @@ public class PhotoEditorPlugin extends Plugin {
                     null,
                     null,
                     () -> {
-                        editorStickerPickerOpen = false;
                         return Unit.a;
                     }
             );
@@ -1219,7 +1470,6 @@ public class PhotoEditorPlugin extends Plugin {
     }
 
     private void addPickedSticker(Context context, PhotoEditor editor, PhotoEditorView editorView, Sticker sticker) {
-        editorStickerPickerOpen = false;
         if (sticker == null)
             return;
 
@@ -1912,12 +2162,24 @@ public class PhotoEditorPlugin extends Plugin {
         button.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
         button.setGravity(Gravity.CENTER);
         button.setPadding(dp(14), dp(10), dp(14), dp(10));
+        
+        android.graphics.drawable.GradientDrawable bg = new android.graphics.drawable.GradientDrawable();
         if (primary) {
-            android.graphics.drawable.GradientDrawable bg = new android.graphics.drawable.GradientDrawable();
             bg.setColor(0xff5865f2);
-            bg.setCornerRadius(dp(8));
+        } else {
+            bg.setColor(Color.TRANSPARENT);
+        }
+        bg.setCornerRadius(dp(8));
+        
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            android.content.res.ColorStateList rippleColor = android.content.res.ColorStateList.valueOf(0x40ffffff);
+            android.graphics.drawable.RippleDrawable ripple = new android.graphics.drawable.RippleDrawable(rippleColor, bg, null);
+            button.setBackground(ripple);
+        } else {
             button.setBackground(bg);
         }
+        
+        addPressAnimation(button);
         return button;
     }
 
@@ -2378,6 +2640,38 @@ public class PhotoEditorPlugin extends Plugin {
 
     private int dp(int value) {
         return DimenUtils.dpToPx(value);
+    }
+
+    private void addRipple(View view) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            android.util.TypedValue outValue = new android.util.TypedValue();
+            view.getContext().getTheme().resolveAttribute(android.R.attr.selectableItemBackground, outValue, true);
+            view.setBackgroundResource(outValue.resourceId);
+        }
+    }
+
+    private void addRippleBorderless(View view) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            android.util.TypedValue outValue = new android.util.TypedValue();
+            view.getContext().getTheme().resolveAttribute(android.R.attr.selectableItemBackgroundBorderless, outValue, true);
+            view.setBackgroundResource(outValue.resourceId);
+        }
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private void addPressAnimation(View view) {
+        view.setOnTouchListener((v, event) -> {
+            switch (event.getAction()) {
+                case MotionEvent.ACTION_DOWN:
+                    v.animate().scaleX(0.92f).scaleY(0.92f).setDuration(100).start();
+                    break;
+                case MotionEvent.ACTION_UP:
+                case MotionEvent.ACTION_CANCEL:
+                    v.animate().scaleX(1f).scaleY(1f).setDuration(100).start();
+                    break;
+            }
+            return false;
+        });
     }
 
     private interface EditRequest {

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -308,6 +308,12 @@ public class PhotoEditorPlugin extends Plugin {
         View clearMainBtn = iconButton(context, "Reset", "ucrop_ic_reset", v -> clearAllEditorOverlays(editor, editorView));
         mainToolbar.addView(clearMainBtn);
 
+        final java.lang.reflect.Method[] undoRedoMethods = new java.lang.reflect.Method[2];
+        try {
+            undoRedoMethods[0] = editor.getClass().getDeclaredMethod("isUndoAvailable");
+            undoRedoMethods[1] = editor.getClass().getDeclaredMethod("isRedoAvailable");
+        } catch (Throwable ignored) {}
+
         Runnable stateUpdater = new Runnable() {
             @Override
             public void run() {
@@ -326,10 +332,8 @@ public class PhotoEditorPlugin extends Plugin {
                 boolean canUndo = false;
                 boolean canRedo = false;
                 try {
-                    java.lang.reflect.Method isUndoAvailable = editor.getClass().getDeclaredMethod("isUndoAvailable");
-                    canUndo = (boolean) isUndoAvailable.invoke(editor);
-                    java.lang.reflect.Method isRedoAvailable = editor.getClass().getDeclaredMethod("isRedoAvailable");
-                    canRedo = (boolean) isRedoAvailable.invoke(editor);
+                    if (undoRedoMethods[0] != null) canUndo = (boolean) undoRedoMethods[0].invoke(editor);
+                    if (undoRedoMethods[1] != null) canRedo = (boolean) undoRedoMethods[1].invoke(editor);
                 } catch (Throwable ignored) {}
                 
                 boolean undoActive = hasOverlay || canUndo;
@@ -351,7 +355,7 @@ public class PhotoEditorPlugin extends Plugin {
                 }
                 clearMainBtn.setEnabled(clearActive);
 
-                undoMainBtn.postDelayed(this, 100);
+                undoMainBtn.postDelayed(this, 300);
             }
         };
         undoMainBtn.post(stateUpdater);
@@ -516,7 +520,8 @@ public class PhotoEditorPlugin extends Plugin {
 
                     FragmentActivity activity = findFragmentActivity(getRealActivity());
                     if (settings.getBool("quick_edit", false) && activity != null && isLikelyImage(attachment)) {
-                        com.aliucord.Utils.mainThread.postDelayed(() -> openEditor(activity, attachment, editRequests.get(attachment), aggregator), 160);
+                        EditRequest editReq = editRequests.get(attachment);
+                        com.aliucord.Utils.mainThread.postDelayed(() -> openEditor(activity, attachment, editReq, aggregator), 160);
                         return null;
                     }
                     try {
@@ -1012,10 +1017,11 @@ public class PhotoEditorPlugin extends Plugin {
             editorStickerPickerOpen = false;
         });
 
-        editorStickerPickerOpen = true;
         try {
+            editorStickerPickerOpen = true;
             dialog.show();
         } catch (android.view.WindowManager.BadTokenException badTokenException) {
+            editorStickerPickerOpen = false;
             logger.error("Failed to show PhotoEditor dialog because the activity window token is invalid", badTokenException);
             Toast.makeText(activity, "Could not open image editor", Toast.LENGTH_SHORT).show();
         }
@@ -2407,6 +2413,9 @@ public class PhotoEditorPlugin extends Plugin {
                 m.postRotate(rotation[0]);
                 if (flip[0]) m.postScale(-1, 1);
                 if (flip[1]) m.postScale(1, -1);
+                if (currentPreview[0] != null && currentPreview[0] != previewBase) {
+                    currentPreview[0].recycle();
+                }
                 currentPreview[0] = Bitmap.createBitmap(previewBase, 0, 0, previewBase.getWidth(), previewBase.getHeight(), m, true);
                 previewImage.setImageBitmap(currentPreview[0]);
                 container.requestLayout();
@@ -2524,6 +2533,9 @@ public class PhotoEditorPlugin extends Plugin {
 
                     if (cropWidth > 10 && cropHeight > 10) {
                         Bitmap cropped = Bitmap.createBitmap(finalRotatedSrc, left, top, cropWidth, cropHeight);
+                        if (finalRotatedSrc != src) {
+                            finalRotatedSrc.recycle();
+                        }
                         targetView.setScaleType(android.widget.ImageView.ScaleType.FIT_XY);
                         targetView.setImageBitmap(cropped);
                         

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -88,11 +88,15 @@ import kotlin.Unit;
 @SuppressWarnings("unused")
 public class PhotoEditorPlugin extends Plugin {
 
+    public PhotoEditorPlugin() {
+        settingsTab = new SettingsTab(PhotoEditorSettings.class, SettingsTab.Type.BOTTOM_SHEET).withArgs(settings);
+    }
+
     public interface SpoilerToggleListener {
         void onSpoilerToggled(boolean isSpoiler);
     }
 
-    private View createToolbar(Context context, PhotoEditor editor, PhotoEditorView editorView, Dialog dialog, Attachment<?> attachment, EditRequest editRequest) {
+    private View createToolbar(Context context, PhotoEditor editor, PhotoEditorView editorView, Dialog dialog, Attachment<?>[] currentAttachment, EditRequest editRequest) {
         LinearLayout rootContainer = new LinearLayout(context);
         rootContainer.setOrientation(LinearLayout.VERTICAL);
         rootContainer.setBackgroundColor(0xff1e1f22);
@@ -290,7 +294,7 @@ public class PhotoEditorPlugin extends Plugin {
         mainToolbar.addView(filterMainBtn);
 
         mainToolbar.addView(groupSeparator(context));
-        View saveBtn = iconButton(context, "Save", "ic_check_circle_24dp", v -> saveImage(context, editor, editorView, attachment, editRequest, dialog, sessionFilter));
+        View saveBtn = iconButton(context, "Save", "ic_check_circle_24dp", v -> saveImage(context, editor, editorView, currentAttachment, editRequest, dialog, sessionFilter));
         mainToolbar.addView(saveBtn);
 
         // Initial state
@@ -350,6 +354,7 @@ public class PhotoEditorPlugin extends Plugin {
         }
     };
     private WeakReference<WidgetChatInputAttachments> latestChatInputAttachments = new WeakReference<>(null);
+    private WeakReference<SelectionAggregator<?>> latestAggregator = new WeakReference<>(null);
     private boolean editorStickerPickerOpen;
     private int brushColor = Color.WHITE;
     private int textColor = Color.WHITE;
@@ -368,11 +373,12 @@ public class PhotoEditorPlugin extends Plugin {
                 new InsteadHook(callFrame -> {
                     SelectionAggregator<?> aggregator = (SelectionAggregator<?>) callFrame.args[0];
                     Attachment<?> attachment = (Attachment<?>) callFrame.args[1];
+                    latestAggregator = new WeakReference<>(aggregator);
                     registerEditRequest(aggregator, attachment);
 
-                    FragmentActivity activity = findFragmentActivity(com.aliucord.Utils.getAppActivity());
-                    if (activity != null && isLikelyImage(attachment)) {
-                        com.aliucord.Utils.mainThread.post(() -> openEditor(activity, attachment, editRequests.get(attachment), aggregator));
+                    FragmentActivity activity = findFragmentActivity(getRealActivity());
+                    if (settings.getBool("quick_edit", false) && activity != null && isLikelyImage(attachment)) {
+                        com.aliucord.Utils.mainThread.postDelayed(() -> openEditor(activity, attachment, editRequests.get(attachment), aggregator), 160);
                         return null;
                     }
                     try {
@@ -465,10 +471,14 @@ public class PhotoEditorPlugin extends Plugin {
     }
 
     private void registerEditRequest(SelectionAggregator<?> aggregator, Attachment<?> attachment) {
-        if (aggregator == null || attachment == null)
-            return;
-
-        editRequests.put(attachment, edited -> replaceAttachment(aggregator, attachment, edited));
+        if (aggregator == null || attachment == null) return;
+        editRequests.put(attachment, (oldAttachment, newAttachment) -> {
+            try {
+                replaceAttachment(aggregator, oldAttachment, newAttachment);
+            } catch (Throwable t) {
+                logger.error("Failed to replace attachment", t);
+            }
+        });
     }
 
     private void registerSentImageContext(AttachmentEntry entry) {
@@ -554,7 +564,7 @@ public class PhotoEditorPlugin extends Plugin {
     private void openSentImageEditor(Context context, SentImageContext sentImageContext) {
         FragmentActivity activity = findFragmentActivity(context);
         if (activity == null)
-            activity = findFragmentActivity(Utils.getAppActivity());
+            activity = findFragmentActivity(getRealActivity());
         if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
             Toast.makeText(context, "Could not open image editor", Toast.LENGTH_SHORT).show();
             return;
@@ -572,7 +582,7 @@ public class PhotoEditorPlugin extends Plugin {
                         null,
                         false
                 );
-                Utils.mainThread.post(() -> openEditor(finalActivity, attachment, edited -> addEditedReplyAttachment(finalActivity, sentImageContext.message, edited), null));
+                Utils.mainThread.post(() -> openEditor(finalActivity, attachment, (oldAttachment, newAttachment) -> addEditedReplyAttachment(finalActivity, sentImageContext.message, newAttachment), null));
             } catch (Throwable throwable) {
                 logger.error("Failed to download sent image for editing", throwable);
                 Utils.mainThread.post(() -> Toast.makeText(context, "Failed to load image for editing", Toast.LENGTH_SHORT).show());
@@ -659,7 +669,7 @@ public class PhotoEditorPlugin extends Plugin {
             edit.setOnClickListener(view -> {
                 FragmentActivity activity = findFragmentActivity(view.getContext());
                 sheet.dismiss();
-                Utils.mainThread.postDelayed(() -> openEditor(activity, attachment, editRequest, null), 160);
+                com.aliucord.Utils.mainThread.postDelayed(() -> openEditor(activity, attachment, editRequest, latestAggregator.get()), 160);
             });
 
             ConstraintLayout.LayoutParams params = new ConstraintLayout.LayoutParams(
@@ -686,13 +696,35 @@ public class PhotoEditorPlugin extends Plugin {
         return remove != null && remove.getParent() instanceof ViewGroup ? (ViewGroup) remove.getParent() : null;
     }
 
-    private void openEditor(Activity passedActivity, Attachment<?> attachment, EditRequest editRequest, SelectionAggregator<?> aggregator) {
-        Activity activity = com.aliucord.Utils.getAppActivity();
-        if (activity == null) {
-            activity = passedActivity;
+    private Activity getRealActivity() {
+        try {
+            Class<?> activityThreadClass = Class.forName("android.app.ActivityThread");
+            Object activityThread = activityThreadClass.getMethod("currentActivityThread").invoke(null);
+            java.lang.reflect.Field activitiesField = activityThreadClass.getDeclaredField("mActivities");
+            activitiesField.setAccessible(true);
+            java.util.Map<?, ?> activities = (java.util.Map<?, ?>) activitiesField.get(activityThread);
+            
+            for (Object activityRecord : activities.values()) {
+                java.lang.reflect.Field activityField = activityRecord.getClass().getDeclaredField("activity");
+                activityField.setAccessible(true);
+                Activity activity = (Activity) activityField.get(activityRecord);
+                if (activity != null && !activity.isFinishing() && (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.JELLY_BEAN_MR1 || !activity.isDestroyed())) {
+                    return activity;
+                }
+            }
+        } catch (Throwable t) {
+            logger.error("Failed to get active activity from ActivityThread", t);
         }
-        if (activity == null) {
-            android.widget.Toast.makeText(com.aliucord.Utils.getAppActivity(), "Could not open image editor (activity null)", android.widget.Toast.LENGTH_SHORT).show();
+        return com.aliucord.Utils.getAppActivity();
+    }
+
+    private void openEditor(Activity passedActivity, Attachment<?> attachment, EditRequest editRequest, SelectionAggregator<?> aggregator) {
+        Activity activity = passedActivity;
+        if (activity == null || activity.isFinishing() || (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1 && activity.isDestroyed())) {
+            activity = getRealActivity();
+        }
+        if (activity == null || activity.isFinishing() || (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1 && activity.isDestroyed())) {
+            android.widget.Toast.makeText(getRealActivity(), "Could not open image editor (activity null or destroyed)", android.widget.Toast.LENGTH_SHORT).show();
             return;
         }
         if (attachment.getUri() == null) {
@@ -707,6 +739,8 @@ public class PhotoEditorPlugin extends Plugin {
                 .setPinchTextScalable(true)
                 .setClipSourceImage(false)
                 .build();
+
+        final Attachment<?>[] currentAttachment = {attachment};
 
         FrameLayout spoilerOverlay = new FrameLayout(activity);
         spoilerOverlay.setBackgroundColor(0x99000000);
@@ -753,7 +787,7 @@ public class PhotoEditorPlugin extends Plugin {
                 ViewGroup.LayoutParams.MATCH_PARENT
         ));
 
-        View header = createHeader(activity, attachment, aggregator, view -> dialog.dismiss(), isSpoiler -> {
+        View header = createHeader(activity, currentAttachment, aggregator, view -> dialog.dismiss(), isSpoiler -> {
             if (isSpoiler) {
                 spoilerOverlay.setVisibility(View.VISIBLE);
                 spoilerOverlay.setAlpha(0f);
@@ -798,7 +832,7 @@ public class PhotoEditorPlugin extends Plugin {
                 Gravity.CENTER
         ));
 
-        content.addView(createToolbar(activity, editor, editorView, dialog, attachment, editRequest), new LinearLayout.LayoutParams(
+        content.addView(createToolbar(activity, editor, editorView, dialog, currentAttachment, editRequest), new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
         ));
@@ -814,7 +848,7 @@ public class PhotoEditorPlugin extends Plugin {
             Window shownWindow = dialog.getWindow();
             if (shownWindow != null)
                 shownWindow.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
-            loadImage(attachment.getUri(), editorView, editorHolder, progressBar);
+            loadImage(currentAttachment[0].getUri(), editorView, editorHolder, progressBar);
             applyBrush(editor);
         });
         dialog.setOnDismissListener(ignored -> {
@@ -830,7 +864,7 @@ public class PhotoEditorPlugin extends Plugin {
         }
     }
 
-    private View createHeader(Context context, Attachment<?> attachment, SelectionAggregator<?> aggregator, View.OnClickListener onClose, SpoilerToggleListener spoilerListener) {
+    private View createHeader(Context context, Attachment<?>[] currentAttachment, SelectionAggregator<?> aggregator, View.OnClickListener onClose, SpoilerToggleListener spoilerListener) {
         LinearLayout header = new LinearLayout(context);
         header.setOrientation(LinearLayout.HORIZONTAL);
         header.setGravity(Gravity.CENTER_VERTICAL);
@@ -855,7 +889,7 @@ public class PhotoEditorPlugin extends Plugin {
         header.addView(closeBtn);
 
         TextView title = new TextView(context);
-        String displayName = attachment.getDisplayName();
+        String displayName = currentAttachment[0].getDisplayName();
         title.setText(displayName == null ? "PhotoEditor" : displayName);
         title.setTextColor(Color.WHITE);
         title.setTextSize(16f);
@@ -874,7 +908,7 @@ public class PhotoEditorPlugin extends Plugin {
             if (eyeOpenId == 0) eyeOpenId = android.R.drawable.ic_menu_view;
             if (eyeClosedId == 0) eyeClosedId = android.R.drawable.ic_menu_view;
 
-            boolean[] isSpoiler = {attachment.getSpoiler()};
+            boolean[] isSpoiler = {currentAttachment[0].getSpoiler()};
             spoilerBtn.setImageResource(isSpoiler[0] ? eyeClosedId : eyeOpenId);
             spoilerBtn.setColorFilter(isSpoiler[0] ? 0xffda373c : Color.WHITE);
             spoilerBtn.setPadding(dp(8), dp(8), dp(8), dp(8));
@@ -891,13 +925,14 @@ public class PhotoEditorPlugin extends Plugin {
                 
                 try {
                     Attachment<?> edited = new Attachment<>(
-                            attachment.getId(),
-                            attachment.getUri(),
-                            attachment.getDisplayName(),
+                            currentAttachment[0].getId(),
+                            currentAttachment[0].getUri(),
+                            currentAttachment[0].getDisplayName(),
                             null,
                             isSpoiler[0]
                     );
-                    replaceAttachment(aggregator, attachment, edited);
+                    replaceAttachment(aggregator, currentAttachment[0], edited);
+                    currentAttachment[0] = edited;
                     if (spoilerListener != null) {
                         spoilerListener.onSpoilerToggled(isSpoiler[0]);
                     }
@@ -923,7 +958,7 @@ public class PhotoEditorPlugin extends Plugin {
                 try {
                     java.lang.reflect.Method remove = SelectionAggregator.class.getDeclaredMethod("removeItem", Attachment.class);
                     remove.setAccessible(true);
-                    remove.invoke(aggregator, attachment);
+                    remove.invoke(aggregator, currentAttachment[0]);
                     onClose.onClick(v);
                 } catch (Throwable t) {
                     logger.error("Failed to delete attachment", t);
@@ -1106,7 +1141,8 @@ public class PhotoEditorPlugin extends Plugin {
     }
 
     private void showImagePicker(Context context, PhotoEditor editor, PhotoEditorView editorView) {
-        androidx.fragment.app.FragmentActivity activity = findFragmentActivity(com.aliucord.Utils.getAppActivity());
+        androidx.fragment.app.FragmentActivity activity = findFragmentActivity(context);
+        if (activity == null) activity = findFragmentActivity(getRealActivity());
         if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
             android.widget.Toast.makeText(context, "Could not open image picker", android.widget.Toast.LENGTH_SHORT).show();
             return;
@@ -1349,7 +1385,7 @@ public class PhotoEditorPlugin extends Plugin {
     private void showDiscordEmojiPicker(Context context, PhotoEditor editor, PhotoEditorView editorView) {
         FragmentActivity activity = findFragmentActivity(context);
         if (activity == null)
-            activity = findFragmentActivity(Utils.getAppActivity());
+            activity = findFragmentActivity(getRealActivity());
 
         if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
             Toast.makeText(context, "Could not open Discord emoji picker", Toast.LENGTH_SHORT).show();
@@ -1378,7 +1414,7 @@ public class PhotoEditorPlugin extends Plugin {
     private void showDiscordStickerPicker(Context context, PhotoEditor editor, PhotoEditorView editorView) {
         FragmentActivity activity = findFragmentActivity(context);
         if (activity == null)
-            activity = findFragmentActivity(Utils.getAppActivity());
+            activity = findFragmentActivity(getRealActivity());
 
         if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
             Toast.makeText(context, "Could not open Discord sticker picker", Toast.LENGTH_SHORT).show();
@@ -1867,7 +1903,7 @@ public class PhotoEditorPlugin extends Plugin {
                 logger.error(throwable);
                 Utils.mainThread.post(() -> {
                     progressBar.setVisibility(View.GONE);
-                    Toast.makeText(Utils.getAppActivity(), "Failed to load image", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(editorView.getContext(), "Failed to load image", Toast.LENGTH_SHORT).show();
                 });
             }
         });
@@ -2329,7 +2365,7 @@ public class PhotoEditorPlugin extends Plugin {
         }
     }
 
-        private void saveImage(Context context, PhotoEditor editor, PhotoEditorView editorView, Attachment<?> original, EditRequest editRequest, Dialog dialog, PhotoFilter[] sessionFilter) {
+        private void saveImage(Context context, PhotoEditor editor, PhotoEditorView editorView, Attachment<?>[] currentAttachment, EditRequest editRequest, Dialog dialog, PhotoFilter[] sessionFilter) {
         try {
             editor.clearHelperBox();
 
@@ -2374,7 +2410,7 @@ public class PhotoEditorPlugin extends Plugin {
                                 child.draw(canvas);
                                 canvas.restore();
                             }
-                            writeBitmapToFile(context, original, editRequest, dialog, activeFilter, glBitmap);
+                            writeBitmapToFile(context, currentAttachment, editRequest, dialog, activeFilter, glBitmap);
                         } else {
                             Toast.makeText(context, "Failed to capture GL filter: " + copyResult, Toast.LENGTH_SHORT).show();
                         }
@@ -2415,16 +2451,17 @@ public class PhotoEditorPlugin extends Plugin {
             }
             canvas.restore();
 
-            writeBitmapToFile(context, original, editRequest, dialog, activeFilter, saveBitmap);
+            writeBitmapToFile(context, currentAttachment, editRequest, dialog, activeFilter, saveBitmap);
         } catch (Throwable throwable) {
             logger.error(throwable);
             Toast.makeText(context, "Failed to render image: " + throwable.getMessage(), Toast.LENGTH_LONG).show();
         }
     }
 
-    private void writeBitmapToFile(Context context, Attachment<?> original, EditRequest editRequest, Dialog dialog, PhotoFilter activeFilter, Bitmap finalBitmap) {
+    private void writeBitmapToFile(Context context, Attachment<?>[] currentAttachment, EditRequest editRequest, Dialog dialog, PhotoFilter activeFilter, Bitmap finalBitmap) {
         Utils.threadPool.execute(() -> {
             try {
+                Attachment<?> original = currentAttachment[0];
                 File output = nextOutputFile(context, original.getDisplayName());
                 try (FileOutputStream stream = new FileOutputStream(output)) {
                     finalBitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
@@ -2441,7 +2478,7 @@ public class PhotoEditorPlugin extends Plugin {
                 String filterDesc = (activeFilter != null && activeFilter != PhotoFilter.NONE)
                         ? " (" + humanize(activeFilter.name()) + " filter)" : "";
                 Utils.mainThread.post(() -> {
-                    editRequest.onEdited(edited);
+                    editRequest.onEdited(original, edited);
                     Toast.makeText(context, "Saved" + filterDesc, Toast.LENGTH_SHORT).show();
                     dialog.dismiss();
                 });
@@ -2675,7 +2712,7 @@ public class PhotoEditorPlugin extends Plugin {
     }
 
     private interface EditRequest {
-        void onEdited(Attachment<?> edited);
+        void onEdited(Attachment<?> oldAttachment, Attachment<?> newAttachment);
     }
 
     private class SentImageContext {

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -255,6 +255,7 @@ public class PhotoEditorPlugin extends Plugin {
                         child.setVisibility(android.view.View.VISIBLE);
                     }
                 }
+                editorView.setLayerType(android.view.View.LAYER_TYPE_NONE, null);
                 editorView.getSource().clearColorFilter();
                 sessionFilter[0] = filter;
                 selectedFilter = filter;
@@ -3186,7 +3187,10 @@ public class PhotoEditorPlugin extends Plugin {
 
             Paint srcPaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.FILTER_BITMAP_FLAG);
             float[] matrix = isCustomFilter != null && isCustomFilter[0] ? buildCustomMatrix(customFilterValues) : getColorMatrixForFilter(activeFilter);
-            if (matrix != null) {
+            
+            boolean applyToEverything = settings.getInt("filter_apply_mode", 0) == 1;
+            
+            if (matrix != null && !applyToEverything) {
                 srcPaint.setColorFilter(new android.graphics.ColorMatrixColorFilter(matrix));
             }
             canvas.drawBitmap(srcBitmap, 0, 0, srcPaint);
@@ -3209,6 +3213,16 @@ public class PhotoEditorPlugin extends Plugin {
                 canvas.restore();
             }
             canvas.restore();
+
+            if (matrix != null && applyToEverything) {
+                Bitmap finalSaveBitmap = Bitmap.createBitmap(outW, outH, Bitmap.Config.ARGB_8888);
+                Canvas finalCanvas = new Canvas(finalSaveBitmap);
+                Paint finalPaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.FILTER_BITMAP_FLAG);
+                finalPaint.setColorFilter(new android.graphics.ColorMatrixColorFilter(matrix));
+                finalCanvas.drawBitmap(saveBitmap, 0, 0, finalPaint);
+                saveBitmap.recycle();
+                saveBitmap = finalSaveBitmap;
+            }
 
             writeBitmapToFile(context, currentAttachment, editRequest, dialog, activeFilter, saveBitmap);
         } catch (Throwable throwable) {
@@ -3546,7 +3560,16 @@ public class PhotoEditorPlugin extends Plugin {
                 }
             }
             float[] matrix = buildCustomMatrix(customFilterValues);
-            editorView.getSource().setColorFilter(new android.graphics.ColorMatrixColorFilter(matrix));
+            boolean applyToEverything = settings.getInt("filter_apply_mode", 0) == 1;
+            if (applyToEverything) {
+                Paint p = new Paint();
+                p.setColorFilter(new android.graphics.ColorMatrixColorFilter(matrix));
+                editorView.setLayerType(android.view.View.LAYER_TYPE_HARDWARE, p);
+                editorView.getSource().clearColorFilter();
+            } else {
+                editorView.setLayerType(android.view.View.LAYER_TYPE_NONE, null);
+                editorView.getSource().setColorFilter(new android.graphics.ColorMatrixColorFilter(matrix));
+            }
         };
 
         String[] labels = {"Brightness", "Contrast", "Saturation", "Hue", "Temperature", "Tint"};

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -371,19 +371,44 @@ public class PhotoEditorPlugin extends Plugin {
         mainButtons.add(drawMainBtn);
         mainToolbar.addView(drawMainBtn);
 
-        View textMainBtn = iconButton(context, "Text", "ic_text_image_24dp", v -> showTextDialog(context, editor, editorView));
+        View textMainBtn = iconButton(context, "Text", "ic_text_image_24dp", v -> {
+            selectOnly(mainButtons, null);
+            subToolbarContainer.setVisibility(View.GONE);
+            editor.setBrushDrawingMode(false);
+            showTextDialog(context, editor, editorView);
+        });
         mainToolbar.addView(textMainBtn);
 
-        View emojiMainBtn = iconButton(context, "Emoji", "ic_emoji_24dp", v -> showDiscordEmojiPicker(context, editor, editorView));
+        View emojiMainBtn = iconButton(context, "Emoji", "ic_emoji_24dp", v -> {
+            selectOnly(mainButtons, null);
+            subToolbarContainer.setVisibility(View.GONE);
+            editor.setBrushDrawingMode(false);
+            showDiscordEmojiPicker(context, editor, editorView);
+        });
         mainToolbar.addView(emojiMainBtn);
 
-        View stickerMainBtn = iconButton(context, "Sticker", "ic_sticker_icon_24dp", v -> showDiscordStickerPicker(context, editor, editorView));
+        View stickerMainBtn = iconButton(context, "Sticker", "ic_sticker_icon_24dp", v -> {
+            selectOnly(mainButtons, null);
+            subToolbarContainer.setVisibility(View.GONE);
+            editor.setBrushDrawingMode(false);
+            showDiscordStickerPicker(context, editor, editorView);
+        });
         mainToolbar.addView(stickerMainBtn);
 
-        View imageMainBtn = iconButton(context, "Image", "ic_photo_grey_24dp", v -> showImagePicker(context, editor, editorView));
+        View imageMainBtn = iconButton(context, "Image", "ic_photo_grey_24dp", v -> {
+            selectOnly(mainButtons, null);
+            subToolbarContainer.setVisibility(View.GONE);
+            editor.setBrushDrawingMode(false);
+            showImagePicker(context, editor, editorView);
+        });
         mainToolbar.addView(imageMainBtn);
 
-        View cropMainBtn = iconButton(context, "Crop", "ucrop_ic_crop", v -> showCropDialog(context, editorView.getSource(), editorView));
+        View cropMainBtn = iconButton(context, "Crop", "ucrop_ic_crop", v -> {
+            selectOnly(mainButtons, null);
+            subToolbarContainer.setVisibility(View.GONE);
+            editor.setBrushDrawingMode(false);
+            showCropDialog(context, editorView.getSource(), editorView);
+        });
         mainToolbar.addView(cropMainBtn);
 
         int filterIconId = Utils.getResId("ic_flare_24dp", "drawable");

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -229,7 +229,7 @@ public class PhotoEditorPlugin extends Plugin {
         }
 
         // --- MAIN TOOLBAR ---
-        mainToolbar.addView(iconButton(context, "Undo", "ic_reply_24dp", v -> {
+        View undoMainBtn = iconButton(context, "Undo", "ic_reply_24dp", v -> {
             boolean undidOverlay = false;
             for (int i = editorView.getChildCount() - 1; i >= 0; i--) {
                 View child = editorView.getChildAt(i);
@@ -241,7 +241,8 @@ public class PhotoEditorPlugin extends Plugin {
                 }
             }
             if (!undidOverlay) editor.undo();
-        }));
+        });
+        mainToolbar.addView(undoMainBtn);
 
         View redoMainBtn = iconButton(context, "Redo", "ic_reply_24dp", v -> editor.redo());
         if (redoMainBtn instanceof android.view.ViewGroup && ((android.view.ViewGroup) redoMainBtn).getChildCount() > 0) {
@@ -249,7 +250,56 @@ public class PhotoEditorPlugin extends Plugin {
         }
         mainToolbar.addView(redoMainBtn);
 
-        mainToolbar.addView(iconButton(context, "Reset", "ic_refresh_white_a60_24dp", v -> clearAllEditorOverlays(editor, editorView)));
+        View clearMainBtn = iconButton(context, "Reset", "ucrop_ic_reset", v -> clearAllEditorOverlays(editor, editorView));
+        mainToolbar.addView(clearMainBtn);
+
+        Runnable stateUpdater = new Runnable() {
+            @Override
+            public void run() {
+                if (undoMainBtn.getParent() == null) return;
+                
+                boolean hasOverlay = false;
+                for (int i = 0; i < editorView.getChildCount(); i++) {
+                    View child = editorView.getChildAt(i);
+                    Object tag = child.getTag();
+                    if (OVERLAY_IMAGE.equals(tag) || OVERLAY_TEXT.equals(tag) || OVERLAY_EMOJI.equals(tag)) {
+                        hasOverlay = true;
+                        break;
+                    }
+                }
+                
+                boolean canUndo = false;
+                boolean canRedo = false;
+                try {
+                    java.lang.reflect.Method isUndoAvailable = editor.getClass().getDeclaredMethod("isUndoAvailable");
+                    canUndo = (boolean) isUndoAvailable.invoke(editor);
+                    java.lang.reflect.Method isRedoAvailable = editor.getClass().getDeclaredMethod("isRedoAvailable");
+                    canRedo = (boolean) isRedoAvailable.invoke(editor);
+                } catch (Throwable ignored) {}
+                
+                boolean undoActive = hasOverlay || canUndo;
+                boolean redoActive = canRedo;
+                boolean clearActive = hasOverlay || canUndo || canRedo;
+                
+                if (undoMainBtn instanceof android.view.ViewGroup && ((android.view.ViewGroup) undoMainBtn).getChildCount() > 0) {
+                    ((android.view.ViewGroup) undoMainBtn).getChildAt(0).setAlpha(undoActive ? 1f : 0.3f);
+                }
+                undoMainBtn.setEnabled(undoActive);
+
+                if (redoMainBtn instanceof android.view.ViewGroup && ((android.view.ViewGroup) redoMainBtn).getChildCount() > 0) {
+                    ((android.view.ViewGroup) redoMainBtn).getChildAt(0).setAlpha(redoActive ? 1f : 0.3f);
+                }
+                redoMainBtn.setEnabled(redoActive);
+
+                if (clearMainBtn instanceof android.view.ViewGroup && ((android.view.ViewGroup) clearMainBtn).getChildCount() > 0) {
+                    ((android.view.ViewGroup) clearMainBtn).getChildAt(0).setAlpha(clearActive ? 1f : 0.3f);
+                }
+                clearMainBtn.setEnabled(clearActive);
+
+                undoMainBtn.postDelayed(this, 100);
+            }
+        };
+        undoMainBtn.post(stateUpdater);
 
         mainToolbar.addView(groupSeparator(context));
 

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -1156,6 +1156,11 @@ public class PhotoEditorPlugin extends Plugin {
         if (listener != null)
             container.setOnClickListener(listener);
 
+        container.setOnLongClickListener(v -> {
+            Toast.makeText(context, label, Toast.LENGTH_SHORT).show();
+            return true;
+        });
+
         addPressAnimation(container);
 
         LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -130,19 +130,16 @@ public class PhotoEditorPlugin extends Plugin {
 
         List<View> mainButtons = new ArrayList<>();
         List<View> toolButtons = new ArrayList<>();
-        List<View> sizeButtons = new ArrayList<>();
-        List<View> colorSwatches = new ArrayList<>();
         List<View> filterButtons = new ArrayList<>();
 
         // --- DRAW SUB-TOOLBAR ---
-        android.widget.HorizontalScrollView drawScroll = new android.widget.HorizontalScrollView(context);
-        drawScroll.setHorizontalScrollBarEnabled(false);
+        android.widget.FrameLayout drawScroll = new android.widget.FrameLayout(context);
         LinearLayout drawToolbar = new LinearLayout(context);
         drawToolbar.setOrientation(LinearLayout.HORIZONTAL);
         drawToolbar.setGravity(Gravity.CENTER_VERTICAL);
         drawToolbar.setPadding(dp(8), dp(7), dp(8), dp(7));
-        drawScroll.addView(drawToolbar, new android.widget.HorizontalScrollView.LayoutParams(
-                ViewGroup.LayoutParams.WRAP_CONTENT,
+        drawScroll.addView(drawToolbar, new android.widget.FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
         ));
 
@@ -166,38 +163,69 @@ public class PhotoEditorPlugin extends Plugin {
 
         drawToolbar.addView(groupSeparator(context));
 
-        View thinButton = iconButton(context, "S", null, null);
-        thinButton.setOnClickListener(v -> {
-            selectOnly(sizeButtons, thinButton);
-            brushSize = 12;
-            applyBrush(editor);
-        });
-        sizeButtons.add(thinButton);
-        drawToolbar.addView(thinButton);
+        LinearLayout sliderContainer = new LinearLayout(context);
+        sliderContainer.setOrientation(LinearLayout.HORIZONTAL);
+        sliderContainer.setGravity(Gravity.CENTER_VERTICAL);
+        sliderContainer.setPadding(0, 0, dp(8), 0);
+        
+        TextView sizeLabel = new TextView(context);
+        sizeLabel.setTextColor(Color.WHITE);
+        sizeLabel.setTextSize(14f);
+        
+        // initialize label text with current brushSize
+        String initLabelStr = "S";
+        if (brushSize > 45) initLabelStr = "L";
+        else if (brushSize > 20) initLabelStr = "M";
+        sizeLabel.setText(brushSize + "px (" + initLabelStr + ")");
+        
+        sizeLabel.setPadding(dp(8), 0, dp(4), 0);
+        sliderContainer.addView(sizeLabel);
 
-        View thickButton = iconButton(context, "L", null, null);
-        thickButton.setOnClickListener(v -> {
-            selectOnly(sizeButtons, thickButton);
-            brushSize = 42;
-            applyBrush(editor);
+        android.widget.SeekBar brushSlider = new android.widget.SeekBar(context);
+        brushSlider.setMax(75); // Range: 5 to 80
+        brushSlider.setProgress(brushSize - 5);
+        brushSlider.setPadding(dp(8), 0, dp(8), 0);
+        
+        brushSlider.setOnSeekBarChangeListener(new android.widget.SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(android.widget.SeekBar seekBar, int progress, boolean fromUser) {
+                int newSize = progress + 5;
+                brushSize = newSize;
+                
+                String labelStr = "S";
+                if (newSize > 45) labelStr = "L";
+                else if (newSize > 20) labelStr = "M";
+                
+                sizeLabel.setText(newSize + "px (" + labelStr + ")");
+                
+                editor.setBrushSize((float) newSize);
+                editor.setBrushEraserSize((float) newSize);
+            }
+
+            @Override
+            public void onStartTrackingTouch(android.widget.SeekBar seekBar) {}
+
+            @Override
+            public void onStopTrackingTouch(android.widget.SeekBar seekBar) {}
         });
-        sizeButtons.add(thickButton);
-        drawToolbar.addView(thickButton);
+        
+        sliderContainer.addView(brushSlider, new LinearLayout.LayoutParams(dp(130), ViewGroup.LayoutParams.WRAP_CONTENT));
+        drawToolbar.addView(sliderContainer);
 
         drawToolbar.addView(groupSeparator(context));
 
-        for (int color : COLORS) {
-            View swatch = colorSwatch(context, color, v -> {
-                brushColor = color;
-                textColor = color;
-                selectColorOnly(colorSwatches, color);
+        final View currentColorBtn = colorSwatch(context, brushColor, null);
+        currentColorBtn.setOnClickListener(v -> {
+            showColorPickerDialog(context, editorView, editor, brushColor, newColor -> {
+                brushColor = newColor;
+                textColor = newColor;
+                setColorSwatchSelected(currentColorBtn, newColor, true);
                 editor.setBrushDrawingMode(true);
                 applyBrush(editor);
             });
-            swatch.setTag(color);
-            colorSwatches.add(swatch);
-            drawToolbar.addView(swatch);
-        }
+        });
+        setColorSwatchSelected(currentColorBtn, brushColor, true);
+        drawToolbar.addView(currentColorBtn);
 
         // --- FILTER SUB-TOOLBAR ---
         android.widget.HorizontalScrollView filterScroll = new android.widget.HorizontalScrollView(context);
@@ -353,8 +381,6 @@ public class PhotoEditorPlugin extends Plugin {
         subToolbarContainer.addView(drawScroll);
         subToolbarContainer.setVisibility(View.VISIBLE);
         setToolbarButtonSelected(penButton, true);
-        setToolbarButtonSelected(brushSize <= 12 ? thinButton : thickButton, true);
-        selectColorOnly(colorSwatches, brushColor);
         editor.setBrushDrawingMode(true);
         applyBrush(editor);
 
@@ -1111,6 +1137,214 @@ public class PhotoEditorPlugin extends Plugin {
         params.setMargins(0, 0, dp(8), 0);
         swatch.setLayoutParams(params);
         return swatch;
+    }
+    
+    interface ColorCallback {
+        void onColorPicked(int color);
+    }
+    
+    private void showColorPickerDialog(Context context, PhotoEditorView editorView, PhotoEditor editor, int initialColor, ColorCallback callback) {
+        Dialog dialog = new Dialog(context);
+        
+        LinearLayout root = new LinearLayout(context);
+        root.setOrientation(LinearLayout.VERTICAL);
+        root.setPadding(dp(20), dp(20), dp(20), dp(20));
+        
+        android.graphics.drawable.GradientDrawable rootBg = new android.graphics.drawable.GradientDrawable();
+        rootBg.setColor(0xff2b2d31);
+        rootBg.setCornerRadius(dp(16));
+        root.setBackground(rootBg);
+        
+        // 1. Title Row (Title + Eyedropper)
+        LinearLayout titleRow = new LinearLayout(context);
+        titleRow.setOrientation(LinearLayout.HORIZONTAL);
+        titleRow.setGravity(Gravity.CENTER_VERTICAL);
+        
+        TextView title = new TextView(context);
+        title.setText("Custom Color");
+        title.setTextColor(Color.WHITE);
+        title.setTextSize(18f);
+        title.setTypeface(null, android.graphics.Typeface.BOLD);
+        titleRow.addView(title, new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+        
+        android.widget.ImageView eyedropper = new android.widget.ImageView(context);
+        int dropperId = Utils.getResId("ic_colorize_24dp", "drawable");
+        if (dropperId == 0) dropperId = Utils.getResId("ic_edit_24dp", "drawable");
+        eyedropper.setImageResource(dropperId);
+        eyedropper.setColorFilter(Color.WHITE);
+        eyedropper.setPadding(dp(8), dp(8), dp(8), dp(8));
+        addRippleBorderless(eyedropper);
+        titleRow.addView(eyedropper);
+        root.addView(titleRow);
+
+        // Eyedropper Logic
+        eyedropper.setOnClickListener(v -> {
+            dialog.dismiss();
+            android.widget.Toast.makeText(context, "Tap anywhere on the image to pick a color!", android.widget.Toast.LENGTH_SHORT).show();
+            
+            editor.setBrushDrawingMode(false);
+            editorView.setOnTouchListener(new View.OnTouchListener() {
+                @Override
+                public boolean onTouch(View view, android.view.MotionEvent event) {
+                    int action = event.getAction();
+                    if (action == android.view.MotionEvent.ACTION_DOWN || action == android.view.MotionEvent.ACTION_MOVE || action == android.view.MotionEvent.ACTION_UP) {
+                        try {
+                            android.widget.ImageView source = editorView.getSource();
+                            android.graphics.drawable.BitmapDrawable drawable = (android.graphics.drawable.BitmapDrawable) source.getDrawable();
+                            android.graphics.Bitmap bitmap = drawable.getBitmap();
+                            
+                            android.graphics.Matrix inverse = new android.graphics.Matrix();
+                            source.getImageMatrix().invert(inverse);
+                            float[] pts = {event.getX(), event.getY()};
+                            inverse.mapPoints(pts);
+                            
+                            int x = (int) pts[0];
+                            int y = (int) pts[1];
+                            
+                            if (x >= 0 && y >= 0 && x < bitmap.getWidth() && y < bitmap.getHeight()) {
+                                int pixel = bitmap.getPixel(x, y);
+                                callback.onColorPicked(pixel);
+                            }
+                        } catch (Throwable t) {
+                            // Silently ignore out of bounds during drag
+                        }
+                        
+                        if (action == android.view.MotionEvent.ACTION_UP) {
+                            editorView.setOnTouchListener(null);
+                            editor.setBrushDrawingMode(true);
+                        }
+                        return true;
+                    }
+                    return false;
+                }
+            });
+        });
+        
+        // 2. Preview Box and HEX
+        LinearLayout previewRow = new LinearLayout(context);
+        previewRow.setOrientation(LinearLayout.HORIZONTAL);
+        previewRow.setGravity(Gravity.CENTER_VERTICAL);
+        previewRow.setPadding(0, dp(16), 0, dp(16));
+        
+        View previewBox = new View(context);
+        android.graphics.drawable.GradientDrawable boxBg = new android.graphics.drawable.GradientDrawable();
+        boxBg.setCornerRadius(dp(8));
+        boxBg.setColor(initialColor);
+        previewBox.setBackground(boxBg);
+        previewRow.addView(previewBox, new LinearLayout.LayoutParams(dp(48), dp(48)));
+        
+        android.widget.EditText hexInput = new android.widget.EditText(context);
+        hexInput.setTextColor(Color.WHITE);
+        hexInput.setText(String.format("#%06X", (0xFFFFFF & initialColor)));
+        hexInput.setSingleLine(true);
+        LinearLayout.LayoutParams hexParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        hexParams.setMargins(dp(16), 0, 0, 0);
+        previewRow.addView(hexInput, hexParams);
+        root.addView(previewRow);
+        
+        // 3. HSV Sliders
+        float[] hsv = new float[3];
+        Color.colorToHSV(initialColor, hsv);
+        
+        TextView hueLabel = new TextView(context); hueLabel.setText("Hue"); hueLabel.setTextColor(Color.LTGRAY); root.addView(hueLabel);
+        android.widget.SeekBar hueSlider = new android.widget.SeekBar(context); hueSlider.setMax(360); hueSlider.setProgress((int) hsv[0]); root.addView(hueSlider);
+        
+        TextView satLabel = new TextView(context); satLabel.setText("Saturation"); satLabel.setTextColor(Color.LTGRAY); satLabel.setPadding(0, dp(8), 0, 0); root.addView(satLabel);
+        android.widget.SeekBar satSlider = new android.widget.SeekBar(context); satSlider.setMax(100); satSlider.setProgress((int) (hsv[1] * 100)); root.addView(satSlider);
+        
+        TextView valLabel = new TextView(context); valLabel.setText("Lightness"); valLabel.setTextColor(Color.LTGRAY); valLabel.setPadding(0, dp(8), 0, 0); root.addView(valLabel);
+        android.widget.SeekBar valSlider = new android.widget.SeekBar(context); valSlider.setMax(100); valSlider.setProgress((int) (hsv[2] * 100)); root.addView(valSlider);
+        
+        // 4. Presets Horizontal Scroll
+        android.widget.HorizontalScrollView presetScroll = new android.widget.HorizontalScrollView(context);
+        presetScroll.setHorizontalScrollBarEnabled(false);
+        LinearLayout presetContainer = new LinearLayout(context);
+        presetContainer.setOrientation(LinearLayout.HORIZONTAL);
+        presetContainer.setPadding(0, dp(16), 0, dp(16));
+        for (int c : COLORS) {
+            View swatch = new View(context);
+            android.graphics.drawable.GradientDrawable swBg = new android.graphics.drawable.GradientDrawable();
+            swBg.setCornerRadius(dp(16)); swBg.setColor(c);
+            swatch.setBackground(swBg);
+            LinearLayout.LayoutParams swParams = new LinearLayout.LayoutParams(dp(32), dp(32));
+            swParams.setMargins(0, 0, dp(8), 0);
+            swatch.setLayoutParams(swParams);
+            swatch.setOnClickListener(v -> {
+                Color.colorToHSV(c, hsv);
+                hueSlider.setProgress((int) hsv[0]);
+                satSlider.setProgress((int) (hsv[1] * 100));
+                valSlider.setProgress((int) (hsv[2] * 100));
+            });
+            presetContainer.addView(swatch);
+        }
+        presetScroll.addView(presetContainer);
+        root.addView(presetScroll);
+        
+        // Updates
+        final int[] currentColor = {initialColor};
+        
+        Runnable updateColor = () -> {
+            try {
+                hsv[0] = hueSlider.getProgress();
+                hsv[1] = satSlider.getProgress() / 100f;
+                hsv[2] = valSlider.getProgress() / 100f;
+                currentColor[0] = Color.HSVToColor(hsv);
+                boxBg.setColor(currentColor[0]);
+                previewBox.invalidate();
+                if (!hexInput.hasFocus()) {
+                    hexInput.setText(String.format("#%06X", (0xFFFFFF & currentColor[0])));
+                }
+            } catch (Exception e) {}
+        };
+        
+        android.widget.SeekBar.OnSeekBarChangeListener sliderListener = new android.widget.SeekBar.OnSeekBarChangeListener() {
+            @Override public void onProgressChanged(android.widget.SeekBar seekBar, int progress, boolean fromUser) { updateColor.run(); }
+            @Override public void onStartTrackingTouch(android.widget.SeekBar seekBar) {}
+            @Override public void onStopTrackingTouch(android.widget.SeekBar seekBar) {}
+        };
+        hueSlider.setOnSeekBarChangeListener(sliderListener);
+        satSlider.setOnSeekBarChangeListener(sliderListener);
+        valSlider.setOnSeekBarChangeListener(sliderListener);
+        
+        hexInput.addTextChangedListener(new android.text.TextWatcher() {
+            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override public void onTextChanged(CharSequence s, int start, int before, int count) {}
+            @Override public void afterTextChanged(android.text.Editable s) {
+                if (hexInput.hasFocus() && s.toString().startsWith("#")) {
+                    try {
+                        int c = Color.parseColor(s.toString());
+                        currentColor[0] = c;
+                        boxBg.setColor(c);
+                        Color.colorToHSV(c, hsv);
+                        hueSlider.setProgress((int) hsv[0]);
+                        satSlider.setProgress((int) (hsv[1] * 100));
+                        valSlider.setProgress((int) (hsv[2] * 100));
+                    } catch (Exception ignored) {}
+                }
+            }
+        });
+        
+        // Buttons
+        LinearLayout btnRow = new LinearLayout(context);
+        btnRow.setOrientation(LinearLayout.HORIZONTAL);
+        btnRow.setGravity(Gravity.RIGHT);
+        
+        TextView cancel = new TextView(context); cancel.setText("Cancel"); cancel.setTextColor(Color.GRAY); cancel.setPadding(dp(16), dp(8), dp(16), dp(8));
+        cancel.setOnClickListener(v -> dialog.dismiss());
+        btnRow.addView(cancel);
+        
+        TextView apply = new TextView(context); apply.setText("Select"); apply.setTextColor(0xff5865f2); apply.setPadding(dp(16), dp(8), dp(16), dp(8)); apply.setTypeface(null, android.graphics.Typeface.BOLD);
+        apply.setOnClickListener(v -> {
+            callback.onColorPicked(currentColor[0]);
+            dialog.dismiss();
+        });
+        btnRow.addView(apply);
+        
+        root.addView(btnRow);
+        
+        dialog.setContentView(root);
+        dialog.getWindow().setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(Color.TRANSPARENT));
+        dialog.show();
     }
 
     private void setToolbarButtonSelected(View button, boolean selected) {

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -379,7 +379,7 @@ public class PhotoEditorPlugin extends Plugin {
         View imageMainBtn = iconButton(context, "Image", "ic_photo_grey_24dp", v -> showImagePicker(context, editor, editorView));
         mainToolbar.addView(imageMainBtn);
 
-        View cropMainBtn = iconButton(context, "Crop", "ucrop_ic_crop", v -> showCropDialog(context, editorView));
+        View cropMainBtn = iconButton(context, "Crop", "ucrop_ic_crop", v -> showCropDialog(context, editorView.getSource(), editorView));
         mainToolbar.addView(cropMainBtn);
 
         int filterIconId = Utils.getResId("ic_flare_24dp", "drawable");
@@ -2293,9 +2293,9 @@ public class PhotoEditorPlugin extends Plugin {
         });
     }
 
-    private void showCropDialog(Context context, PhotoEditorView editorView) {
+    private void showCropDialog(Context context, android.widget.ImageView targetView, PhotoEditorView editorView) {
         try {
-            android.graphics.drawable.BitmapDrawable drawable = (android.graphics.drawable.BitmapDrawable) editorView.getSource().getDrawable();
+            android.graphics.drawable.BitmapDrawable drawable = (android.graphics.drawable.BitmapDrawable) targetView.getDrawable();
             if (drawable == null) {
                 Toast.makeText(context, "No image to crop", Toast.LENGTH_SHORT).show();
                 return;
@@ -2416,31 +2416,19 @@ public class PhotoEditorPlugin extends Plugin {
             mirrorRow.setGravity(Gravity.CENTER);
             mirrorRow.setPadding(0, dp(8), 0, 0);
 
-            TextView flipHBtn = new TextView(context);
-            flipHBtn.setText("Flip H");
-            flipHBtn.setTextColor(Color.parseColor("#dbdee1"));
-            flipHBtn.setPadding(dp(16), dp(8), dp(16), dp(8));
-            flipHBtn.setOnClickListener(v -> {
+            View flipHBtn = iconButton(context, "Flip H", "ic_swap_horiz_24dp", v -> {
                 flip[0] = !flip[0];
                 updatePreview.run();
             });
             mirrorRow.addView(flipHBtn);
 
-            TextView flipVBtn = new TextView(context);
-            flipVBtn.setText("Flip V");
-            flipVBtn.setTextColor(Color.parseColor("#dbdee1"));
-            flipVBtn.setPadding(dp(16), dp(8), dp(16), dp(8));
-            flipVBtn.setOnClickListener(v -> {
+            View flipVBtn = iconButton(context, "Flip V", "ic_swap_vert_24dp", v -> {
                 flip[1] = !flip[1];
                 updatePreview.run();
             });
             mirrorRow.addView(flipVBtn);
 
-            TextView rotate90Btn = new TextView(context);
-            rotate90Btn.setText("Rotate 90°");
-            rotate90Btn.setTextColor(Color.parseColor("#dbdee1"));
-            rotate90Btn.setPadding(dp(16), dp(8), dp(16), dp(8));
-            rotate90Btn.setOnClickListener(v -> {
+            View rotate90Btn = iconButton(context, "Rotate 90°", "ucrop_ic_rotate", v -> {
                 float newRot = rotation[0] + 90f;
                 if (newRot > 180f) newRot -= 360f;
                 rotation[0] = newRot;
@@ -2500,11 +2488,16 @@ public class PhotoEditorPlugin extends Plugin {
 
                     if (cropWidth > 10 && cropHeight > 10) {
                         Bitmap cropped = Bitmap.createBitmap(finalRotatedSrc, left, top, cropWidth, cropHeight);
-                        editorView.getSource().setScaleType(android.widget.ImageView.ScaleType.FIT_XY);
-                        editorView.getSource().setImageBitmap(cropped);
-                        fillEditorBaseLayers(editorView);
-                        if (editorView.getParent() instanceof View)
-                            fitEditorToBitmap(editorView, (View) editorView.getParent(), cropped);
+                        targetView.setScaleType(android.widget.ImageView.ScaleType.FIT_XY);
+                        targetView.setImageBitmap(cropped);
+                        
+                        if (targetView == editorView.getSource()) {
+                            fillEditorBaseLayers(editorView);
+                            if (editorView.getParent() instanceof View)
+                                fitEditorToBitmap(editorView, (View) editorView.getParent(), cropped);
+                        } else {
+                            targetView.requestLayout();
+                        }
                         Toast.makeText(context, "Cropped successfully", Toast.LENGTH_SHORT).show();
                     }
                 } catch (Throwable e) {
@@ -2658,7 +2651,7 @@ public class PhotoEditorPlugin extends Plugin {
         addManualOverlay(editorView, textView);
     }
 
-    private void showDeleteConfirmDialog(Context context, View viewToRemove, android.view.ViewGroup parent) {
+    private void showOverlayOptionsDialog(Context context, View viewToRemove, android.view.ViewGroup parent) {
         android.app.Dialog dialog = new android.app.Dialog(context);
         dialog.requestWindowFeature(android.view.Window.FEATURE_NO_TITLE);
 
@@ -2672,14 +2665,14 @@ public class PhotoEditorPlugin extends Plugin {
         layout.setBackground(bg);
 
         android.widget.TextView title = new android.widget.TextView(context);
-        title.setText("Remove item?");
+        title.setText("Overlay Options");
         title.setTextColor(android.graphics.Color.WHITE);
         title.setTextSize(20f);
         title.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
         title.setPadding(0, 0, 0, dp(12));
 
         android.widget.TextView message = new android.widget.TextView(context);
-        message.setText("Do you want to delete this item?");
+        message.setText("What would you like to do with this item?");
         message.setTextColor(android.graphics.Color.parseColor("#dbdee1"));
         message.setTextSize(16f);
         message.setPadding(0, 0, 0, dp(24));
@@ -2696,6 +2689,37 @@ public class PhotoEditorPlugin extends Plugin {
         cancel.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
         cancel.setPadding(dp(20), dp(10), dp(20), dp(10));
         cancel.setOnClickListener(v -> dialog.dismiss());
+        buttons.addView(cancel);
+
+        if (viewToRemove instanceof android.widget.ImageView) {
+            android.widget.ImageView iv = (android.widget.ImageView) viewToRemove;
+            if (iv.getDrawable() instanceof android.graphics.drawable.BitmapDrawable) {
+                android.widget.TextView crop = new android.widget.TextView(context);
+                crop.setText("Crop");
+                crop.setTextColor(android.graphics.Color.WHITE);
+                crop.setTextSize(14f);
+                crop.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
+                crop.setPadding(dp(24), dp(10), dp(24), dp(10));
+
+                android.graphics.drawable.GradientDrawable cropBg = new android.graphics.drawable.GradientDrawable();
+                cropBg.setColor(0xff5865f2);
+                cropBg.setCornerRadius(dp(6));
+                crop.setBackground(cropBg);
+
+                android.widget.LinearLayout.LayoutParams cropParams = new android.widget.LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                );
+                cropParams.setMargins(dp(8), 0, dp(8), 0);
+                crop.setLayoutParams(cropParams);
+
+                crop.setOnClickListener(v -> {
+                    dialog.dismiss();
+                    showCropDialog(context, iv, (PhotoEditorView) parent);
+                });
+                buttons.addView(crop);
+            }
+        }
 
         android.widget.TextView delete = new android.widget.TextView(context);
         delete.setText("Delete");
@@ -2709,12 +2733,17 @@ public class PhotoEditorPlugin extends Plugin {
         deleteBg.setCornerRadius(dp(6));
         delete.setBackground(deleteBg);
 
+        android.widget.LinearLayout.LayoutParams delParams = new android.widget.LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        delParams.setMargins(dp(8), 0, 0, 0);
+        delete.setLayoutParams(delParams);
+
         delete.setOnClickListener(v -> {
             parent.removeView(viewToRemove);
             dialog.dismiss();
         });
-
-        buttons.addView(cancel);
         buttons.addView(delete);
 
         layout.addView(title);
@@ -2954,7 +2983,7 @@ public class PhotoEditorPlugin extends Plugin {
                     if (longClickRunnable != null) view.removeCallbacks(longClickRunnable);
                     longClickRunnable = () -> {
                         if (!moved) {
-                            showDeleteConfirmDialog(view.getContext(), view, (android.view.ViewGroup) parent);
+                            showOverlayOptionsDialog(view.getContext(), view, (android.view.ViewGroup) parent);
                         }
                     };
                     view.postDelayed(longClickRunnable, 500);

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -148,6 +148,7 @@ public class PhotoEditorPlugin extends Plugin {
             selectOnly(toolButtons, penButton);
             editor.setBrushDrawingMode(true);
             applyBrush(editor);
+            applyBrushLayerMode(editorView, true);
         });
         toolButtons.add(penButton);
         drawToolbar.addView(penButton);
@@ -157,6 +158,7 @@ public class PhotoEditorPlugin extends Plugin {
             selectOnly(toolButtons, eraseButton);
             editor.setBrushDrawingMode(true);
             editor.brushEraser();
+            applyBrushLayerMode(editorView, true);
         });
         toolButtons.add(eraseButton);
         drawToolbar.addView(eraseButton);
@@ -222,6 +224,7 @@ public class PhotoEditorPlugin extends Plugin {
                 setColorSwatchSelected(currentColorBtn, newColor, true);
                 editor.setBrushDrawingMode(true);
                 applyBrush(editor);
+                applyBrushLayerMode(editorView, true);
             });
         });
         setColorSwatchSelected(currentColorBtn, brushColor, true);
@@ -363,6 +366,7 @@ public class PhotoEditorPlugin extends Plugin {
             selectOnly(toolButtons, penButton);
             editor.setBrushDrawingMode(true);
             applyBrush(editor);
+            applyBrushLayerMode(editorView, true);
         });
         mainButtons.add(drawMainBtn);
         mainToolbar.addView(drawMainBtn);
@@ -411,6 +415,7 @@ public class PhotoEditorPlugin extends Plugin {
         setToolbarButtonSelected(penButton, true);
         editor.setBrushDrawingMode(true);
         applyBrush(editor);
+        applyBrushLayerMode(editorView, true);
 
         return rootContainer;
     }
@@ -2535,6 +2540,38 @@ public class PhotoEditorPlugin extends Plugin {
     }
 
 
+
+    private void applyBrushLayerMode(ja.burhanrashid52.photoeditor.PhotoEditorView editorView, boolean isDrawing) {
+        int mode = settings.getInt("brush_layer_mode", 2); // 0: Behind, 1: Front, 2: Dynamic
+        View drawingView = null;
+        for (int i = 0; i < editorView.getChildCount(); i++) {
+            View child = editorView.getChildAt(i);
+            if (child.getClass().getName().contains("DrawingView")) {
+                drawingView = child;
+                break;
+            }
+        }
+        if (drawingView != null) {
+            if (mode == 0) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    drawingView.setElevation(0f);
+                }
+            } else if (mode == 1) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    drawingView.setElevation(100f);
+                } else {
+                    drawingView.bringToFront();
+                }
+            } else if (mode == 2) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    drawingView.setElevation(0f);
+                }
+                if (isDrawing) {
+                    drawingView.bringToFront();
+                }
+            }
+        }
+    }
 
     private void applyBrush(PhotoEditor editor) {
         editor.setShape(new ShapeBuilder()

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -2316,16 +2316,26 @@ public class PhotoEditorPlugin extends Plugin {
             info.setPadding(0, 0, 0, dp(12));
             layout.addView(info);
 
+            float[] rotation = {0f};
+            boolean[] flip = {false, false};
+            
+            // Create downscaled base for smooth preview dragging
+            int maxDim = Math.max(src.getWidth(), src.getHeight());
+            float downscale = maxDim > 800 ? 800f / maxDim : 1f;
+            Bitmap previewBase = downscale == 1f ? src : Bitmap.createScaledBitmap(src, (int)(src.getWidth() * downscale), (int)(src.getHeight() * downscale), true);
+
+            Bitmap[] currentPreview = {previewBase};
+
             // Container for image and crop overlay
             FrameLayout container = new FrameLayout(context) {
                 @Override
                 protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
                     int width = View.MeasureSpec.getSize(widthMeasureSpec);
-                    int height = (int) (width * ((float) src.getHeight() / src.getWidth()));
+                    int height = (int) (width * ((float) currentPreview[0].getHeight() / currentPreview[0].getWidth()));
                     int maxHeight = dp(350);
                     if (height > maxHeight) {
                         height = maxHeight;
-                        width = (int) (height * ((float) src.getWidth() / src.getHeight()));
+                        width = (int) (height * ((float) currentPreview[0].getWidth() / currentPreview[0].getHeight()));
                     }
                     int wSpec = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY);
                     int hSpec = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY);
@@ -2341,7 +2351,7 @@ public class PhotoEditorPlugin extends Plugin {
             container.setLayoutParams(containerParams);
 
             android.widget.ImageView previewImage = new android.widget.ImageView(context);
-            previewImage.setImageBitmap(src);
+            previewImage.setImageBitmap(currentPreview[0]);
             previewImage.setScaleType(android.widget.ImageView.ScaleType.FIT_XY);
             container.addView(previewImage, new FrameLayout.LayoutParams(
                     ViewGroup.LayoutParams.MATCH_PARENT,
@@ -2355,6 +2365,93 @@ public class PhotoEditorPlugin extends Plugin {
             ));
 
             layout.addView(container);
+
+            Runnable updatePreview = () -> {
+                android.graphics.Matrix m = new android.graphics.Matrix();
+                m.postRotate(rotation[0]);
+                if (flip[0]) m.postScale(-1, 1);
+                if (flip[1]) m.postScale(1, -1);
+                currentPreview[0] = Bitmap.createBitmap(previewBase, 0, 0, previewBase.getWidth(), previewBase.getHeight(), m, true);
+                previewImage.setImageBitmap(currentPreview[0]);
+                container.requestLayout();
+            };
+
+            // Rotation Controls
+            LinearLayout rotateControls = new LinearLayout(context);
+            rotateControls.setOrientation(LinearLayout.VERTICAL);
+            rotateControls.setPadding(0, dp(8), 0, dp(16));
+
+            LinearLayout sliderRow = new LinearLayout(context);
+            sliderRow.setOrientation(LinearLayout.HORIZONTAL);
+            sliderRow.setGravity(Gravity.CENTER_VERTICAL);
+            
+            TextView degreeLabel = new TextView(context);
+            degreeLabel.setText("0°");
+            degreeLabel.setTextColor(Color.WHITE);
+            degreeLabel.setMinWidth(dp(40));
+            degreeLabel.setGravity(Gravity.CENTER);
+            sliderRow.addView(degreeLabel);
+
+            android.widget.SeekBar rotateSlider = new android.widget.SeekBar(context);
+            rotateSlider.setMax(360);
+            rotateSlider.setProgress(180);
+            rotateSlider.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+            rotateSlider.setOnSeekBarChangeListener(new android.widget.SeekBar.OnSeekBarChangeListener() {
+                @Override
+                public void onProgressChanged(android.widget.SeekBar seekBar, int progress, boolean fromUser) {
+                    if (fromUser) {
+                        rotation[0] = progress - 180f;
+                        degreeLabel.setText((int)rotation[0] + "°");
+                        updatePreview.run();
+                    }
+                }
+                @Override public void onStartTrackingTouch(android.widget.SeekBar seekBar) {}
+                @Override public void onStopTrackingTouch(android.widget.SeekBar seekBar) {}
+            });
+            sliderRow.addView(rotateSlider);
+            rotateControls.addView(sliderRow);
+
+            LinearLayout mirrorRow = new LinearLayout(context);
+            mirrorRow.setOrientation(LinearLayout.HORIZONTAL);
+            mirrorRow.setGravity(Gravity.CENTER);
+            mirrorRow.setPadding(0, dp(8), 0, 0);
+
+            TextView flipHBtn = new TextView(context);
+            flipHBtn.setText("Flip H");
+            flipHBtn.setTextColor(Color.parseColor("#dbdee1"));
+            flipHBtn.setPadding(dp(16), dp(8), dp(16), dp(8));
+            flipHBtn.setOnClickListener(v -> {
+                flip[0] = !flip[0];
+                updatePreview.run();
+            });
+            mirrorRow.addView(flipHBtn);
+
+            TextView flipVBtn = new TextView(context);
+            flipVBtn.setText("Flip V");
+            flipVBtn.setTextColor(Color.parseColor("#dbdee1"));
+            flipVBtn.setPadding(dp(16), dp(8), dp(16), dp(8));
+            flipVBtn.setOnClickListener(v -> {
+                flip[1] = !flip[1];
+                updatePreview.run();
+            });
+            mirrorRow.addView(flipVBtn);
+
+            TextView rotate90Btn = new TextView(context);
+            rotate90Btn.setText("Rotate 90°");
+            rotate90Btn.setTextColor(Color.parseColor("#dbdee1"));
+            rotate90Btn.setPadding(dp(16), dp(8), dp(16), dp(8));
+            rotate90Btn.setOnClickListener(v -> {
+                float newRot = rotation[0] + 90f;
+                if (newRot > 180f) newRot -= 360f;
+                rotation[0] = newRot;
+                rotateSlider.setProgress((int)newRot + 180);
+                degreeLabel.setText((int)newRot + "°");
+                updatePreview.run();
+            });
+            mirrorRow.addView(rotate90Btn);
+
+            rotateControls.addView(mirrorRow);
+            layout.addView(rotateControls);
 
             Dialog dialog[] = new Dialog[1];
 
@@ -2382,9 +2479,16 @@ public class PhotoEditorPlugin extends Plugin {
 
             applyBtn.setOnClickListener(v -> {
                 try {
+                    // 1. Generate full-res rotated bitmap
+                    android.graphics.Matrix m = new android.graphics.Matrix();
+                    m.postRotate(rotation[0]);
+                    if (flip[0]) m.postScale(-1, 1);
+                    if (flip[1]) m.postScale(1, -1);
+                    Bitmap finalRotatedSrc = Bitmap.createBitmap(src, 0, 0, src.getWidth(), src.getHeight(), m, true);
+
                     RectF percent = cropOverlay.getCropRectPercent();
-                    int w = src.getWidth();
-                    int h = src.getHeight();
+                    int w = finalRotatedSrc.getWidth();
+                    int h = finalRotatedSrc.getHeight();
 
                     int left = (int) (w * percent.left);
                     int top = (int) (h * percent.top);
@@ -2395,7 +2499,7 @@ public class PhotoEditorPlugin extends Plugin {
                     int cropHeight = bottom - top;
 
                     if (cropWidth > 10 && cropHeight > 10) {
-                        Bitmap cropped = Bitmap.createBitmap(src, left, top, cropWidth, cropHeight);
+                        Bitmap cropped = Bitmap.createBitmap(finalRotatedSrc, left, top, cropWidth, cropHeight);
                         editorView.getSource().setScaleType(android.widget.ImageView.ScaleType.FIT_XY);
                         editorView.getSource().setImageBitmap(cropped);
                         fillEditorBaseLayers(editorView);

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -71,6 +71,7 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -87,6 +88,7 @@ import kotlin.Unit;
 @AliucordPlugin
 @SuppressWarnings("unused")
 public class PhotoEditorPlugin extends Plugin {
+    private final ArrayDeque<View> overlayRedoStack = new ArrayDeque<>();
 
     public PhotoEditorPlugin() {
         settingsTab = new SettingsTab(PhotoEditorSettings.class, SettingsTab.Type.BOTTOM_SHEET).withArgs(settings);
@@ -173,42 +175,24 @@ public class PhotoEditorPlugin extends Plugin {
         TextView sizeLabel = new TextView(context);
         sizeLabel.setTextColor(Color.WHITE);
         sizeLabel.setTextSize(14f);
+        sizeLabel.setGravity(Gravity.END | Gravity.CENTER_VERTICAL);
         
         // initialize label text with current brushSize
-        String initLabelStr = "S";
-        if (brushSize > 45) initLabelStr = "L";
-        else if (brushSize > 20) initLabelStr = "M";
-        sizeLabel.setText(brushSize + "px (" + initLabelStr + ")");
+        sizeLabel.setSingleLine(true);
+        sizeLabel.setText(brushSize + " px");
         
         sizeLabel.setPadding(dp(8), 0, dp(4), 0);
-        sliderContainer.addView(sizeLabel);
+        sliderContainer.addView(sizeLabel, new LinearLayout.LayoutParams(dp(60), ViewGroup.LayoutParams.WRAP_CONTENT));
 
-        android.widget.SeekBar brushSlider = new android.widget.SeekBar(context);
-        brushSlider.setMax(75); // Range: 5 to 80
-        brushSlider.setProgress(brushSize - 5);
+        com.google.android.material.slider.Slider brushSlider = PhotoEditorUi.createDiscordSlider(context, 0, 75, brushSize - 5);
         brushSlider.setPadding(dp(8), 0, dp(8), 0);
         
-        brushSlider.setOnSeekBarChangeListener(new android.widget.SeekBar.OnSeekBarChangeListener() {
-            @Override
-            public void onProgressChanged(android.widget.SeekBar seekBar, int progress, boolean fromUser) {
-                int newSize = progress + 5;
-                brushSize = newSize;
-                
-                String labelStr = "S";
-                if (newSize > 45) labelStr = "L";
-                else if (newSize > 20) labelStr = "M";
-                
-                sizeLabel.setText(newSize + "px (" + labelStr + ")");
-                
-                editor.setBrushSize((float) newSize);
-                editor.setBrushEraserSize((float) newSize);
-            }
-
-            @Override
-            public void onStartTrackingTouch(android.widget.SeekBar seekBar) {}
-
-            @Override
-            public void onStopTrackingTouch(android.widget.SeekBar seekBar) {}
+        brushSlider.addOnChangeListener((slider, value, fromUser) -> {
+            int newSize = Math.round(value) + 5;
+            brushSize = newSize;
+            sizeLabel.setText(newSize + " px");
+            editor.setBrushSize((float) newSize);
+            editor.setBrushEraserSize((float) newSize);
         });
         
         sliderContainer.addView(brushSlider, new LinearLayout.LayoutParams(dp(130), ViewGroup.LayoutParams.WRAP_CONTENT));
@@ -285,21 +269,27 @@ public class PhotoEditorPlugin extends Plugin {
 
         // --- MAIN TOOLBAR ---
         View undoMainBtn = iconButton(context, "Undo", "ic_reply_24dp", v -> {
-            boolean undidOverlay = false;
-            for (int i = editorView.getChildCount() - 1; i >= 0; i--) {
-                View child = editorView.getChildAt(i);
-                Object tag = child.getTag();
-                if (OVERLAY_IMAGE.equals(tag) || OVERLAY_TEXT.equals(tag) || OVERLAY_EMOJI.equals(tag)) {
-                    editorView.removeViewAt(i);
-                    undidOverlay = true;
-                    break;
+            if (!editor.undo()) {
+                for (int i = editorView.getChildCount() - 1; i >= 0; i--) {
+                    View child = editorView.getChildAt(i);
+                    Object tag = child.getTag();
+                    if (OVERLAY_IMAGE.equals(tag) || OVERLAY_TEXT.equals(tag) || OVERLAY_EMOJI.equals(tag)) {
+                        editorView.removeViewAt(i);
+                        overlayRedoStack.push(child);
+                        break;
+                    }
                 }
             }
-            if (!undidOverlay) editor.undo();
         });
         mainToolbar.addView(undoMainBtn);
 
-        View redoMainBtn = iconButton(context, "Redo", "ic_reply_24dp", v -> editor.redo());
+        View redoMainBtn = iconButton(context, "Redo", "ic_reply_24dp", v -> {
+            if (!editor.redo() && !overlayRedoStack.isEmpty()) {
+                View overlay = overlayRedoStack.pop();
+                if (overlay.getParent() == null) editorView.addView(overlay, overlay.getLayoutParams());
+                overlay.bringToFront();
+            }
+        });
         if (redoMainBtn instanceof android.view.ViewGroup && ((android.view.ViewGroup) redoMainBtn).getChildCount() > 0) {
             ((android.view.ViewGroup) redoMainBtn).getChildAt(0).setScaleX(-1f);
         }
@@ -307,14 +297,6 @@ public class PhotoEditorPlugin extends Plugin {
 
         View clearMainBtn = iconButton(context, "Reset", "ucrop_ic_reset", v -> clearAllEditorOverlays(editor, editorView));
         mainToolbar.addView(clearMainBtn);
-
-        final java.lang.reflect.Method[] undoRedoMethods = new java.lang.reflect.Method[2];
-        try {
-            undoRedoMethods[0] = editor.getClass().getDeclaredMethod("isUndoAvailable");
-            undoRedoMethods[0].setAccessible(true);
-            undoRedoMethods[1] = editor.getClass().getDeclaredMethod("isRedoAvailable");
-            undoRedoMethods[1].setAccessible(true);
-        } catch (Throwable ignored) {}
 
         Runnable stateUpdater = new Runnable() {
             @Override
@@ -331,12 +313,8 @@ public class PhotoEditorPlugin extends Plugin {
                     }
                 }
                 
-                boolean canUndo = false;
-                boolean canRedo = false;
-                try {
-                    if (undoRedoMethods[0] != null) canUndo = (boolean) undoRedoMethods[0].invoke(editor);
-                    if (undoRedoMethods[1] != null) canRedo = (boolean) undoRedoMethods[1].invoke(editor);
-                } catch (Throwable ignored) {}
+                boolean canUndo = editor.isUndoAvailable();
+                boolean canRedo = editor.isRedoAvailable() || !overlayRedoStack.isEmpty();
                 
                 boolean undoActive = hasOverlay || canUndo;
                 boolean redoActive = canRedo;
@@ -1315,22 +1293,30 @@ public class PhotoEditorPlugin extends Plugin {
         hexParams.setMargins(dp(16), 0, 0, 0);
         previewRow.addView(hexInput, hexParams);
         root.addView(previewRow);
+
         
         // 3. HSV Sliders
         float[] hsv = new float[3];
         Color.colorToHSV(initialColor, hsv);
         
         TextView hueLabel = new TextView(context); hueLabel.setText("Hue"); hueLabel.setTextColor(Color.LTGRAY); root.addView(hueLabel);
-        android.widget.SeekBar hueSlider = new android.widget.SeekBar(context); hueSlider.setMax(360); hueSlider.setProgress((int) hsv[0]); root.addView(hueSlider);
+        com.google.android.material.slider.Slider hueSlider = PhotoEditorUi.createDiscordSlider(context, 0, 360, hsv[0]); root.addView(hueSlider);
         
         TextView satLabel = new TextView(context); satLabel.setText("Saturation"); satLabel.setTextColor(Color.LTGRAY); satLabel.setPadding(0, dp(8), 0, 0); root.addView(satLabel);
-        android.widget.SeekBar satSlider = new android.widget.SeekBar(context); satSlider.setMax(100); satSlider.setProgress((int) (hsv[1] * 100)); root.addView(satSlider);
+        com.google.android.material.slider.Slider satSlider = PhotoEditorUi.createDiscordSlider(context, 0, 100, hsv[1] * 100); root.addView(satSlider);
         
         TextView valLabel = new TextView(context); valLabel.setText("Lightness"); valLabel.setTextColor(Color.LTGRAY); valLabel.setPadding(0, dp(8), 0, 0); root.addView(valLabel);
-        android.widget.SeekBar valSlider = new android.widget.SeekBar(context); valSlider.setMax(100); valSlider.setProgress((int) (hsv[2] * 100)); root.addView(valSlider);
+        com.google.android.material.slider.Slider valSlider = PhotoEditorUi.createDiscordSlider(context, 0, 100, hsv[2] * 100); root.addView(valSlider);
         
+        final android.widget.ImageView colorPlane = new android.widget.ImageView(context);
+        int colorPlaneSize = dp(180);
+        colorPlane.setImageBitmap(PhotoEditorUi.createColorPlane(colorPlaneSize));
+        colorPlane.setScaleType(android.widget.ImageView.ScaleType.FIT_XY);
+        root.addView(colorPlane, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, colorPlaneSize));
+        colorPlane.setVisibility(View.GONE);
+        previewBox.setOnClickListener(v -> colorPlane.setVisibility(colorPlane.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE));
         TextView alphaLabel = new TextView(context); alphaLabel.setText("Opacity"); alphaLabel.setTextColor(Color.LTGRAY); alphaLabel.setPadding(0, dp(8), 0, 0); root.addView(alphaLabel);
-        android.widget.SeekBar alphaSlider = new android.widget.SeekBar(context); alphaSlider.setMax(255); alphaSlider.setProgress(Color.alpha(initialColor)); root.addView(alphaSlider);
+        com.google.android.material.slider.Slider alphaSlider = PhotoEditorUi.createDiscordSlider(context, 0, 255, Color.alpha(initialColor)); root.addView(alphaSlider);
         
         // 4. Presets Horizontal Scroll
         android.widget.HorizontalScrollView presetScroll = new android.widget.HorizontalScrollView(context);
@@ -1348,10 +1334,10 @@ public class PhotoEditorPlugin extends Plugin {
             swatch.setLayoutParams(swParams);
             swatch.setOnClickListener(v -> {
                 Color.colorToHSV(c, hsv);
-                hueSlider.setProgress((int) hsv[0]);
-                satSlider.setProgress((int) (hsv[1] * 100));
-                valSlider.setProgress((int) (hsv[2] * 100));
-                alphaSlider.setProgress(Color.alpha(c));
+                hueSlider.setValue((int) hsv[0]);
+                satSlider.setValue((int) (hsv[1] * 100));
+                valSlider.setValue((int) (hsv[2] * 100));
+                alphaSlider.setValue(Color.alpha(c));
             });
             presetContainer.addView(swatch);
         }
@@ -1363,10 +1349,10 @@ public class PhotoEditorPlugin extends Plugin {
         
         Runnable updateColor = () -> {
             try {
-                hsv[0] = hueSlider.getProgress();
-                hsv[1] = satSlider.getProgress() / 100f;
-                hsv[2] = valSlider.getProgress() / 100f;
-                int alpha = alphaSlider.getProgress();
+                hsv[0] = hueSlider.getValue();
+                hsv[1] = satSlider.getValue() / 100f;
+                hsv[2] = valSlider.getValue() / 100f;
+                int alpha = Math.round(alphaSlider.getValue());
                 currentColor[0] = Color.HSVToColor(alpha, hsv);
                 boxBg.setColor(currentColor[0]);
                 previewBox.invalidate();
@@ -1376,16 +1362,21 @@ public class PhotoEditorPlugin extends Plugin {
             } catch (Exception e) {}
         };
         
-        android.widget.SeekBar.OnSeekBarChangeListener sliderListener = new android.widget.SeekBar.OnSeekBarChangeListener() {
-            @Override public void onProgressChanged(android.widget.SeekBar seekBar, int progress, boolean fromUser) { updateColor.run(); }
-            @Override public void onStartTrackingTouch(android.widget.SeekBar seekBar) {}
-            @Override public void onStopTrackingTouch(android.widget.SeekBar seekBar) {}
-        };
-        hueSlider.setOnSeekBarChangeListener(sliderListener);
-        satSlider.setOnSeekBarChangeListener(sliderListener);
-        valSlider.setOnSeekBarChangeListener(sliderListener);
-        alphaSlider.setOnSeekBarChangeListener(sliderListener);
-        
+        colorPlane.setOnTouchListener((v, event) -> {
+            float hue = Math.max(0f, Math.min(360f, event.getX() / Math.max(1f, v.getWidth()) * 360f));
+            float position = Math.max(0f, Math.min(1f, event.getY() / Math.max(1f, v.getHeight())));
+            float saturation = position <= 0.5f ? position * 2f : 1f;
+            float value = position <= 0.5f ? 1f : (1f - position) * 2f;
+            hueSlider.setValue(Math.round(hue));
+            satSlider.setValue(Math.round(saturation * 100f));
+            valSlider.setValue(Math.round(value * 100f));
+            return true;
+        });
+        com.google.android.material.slider.Slider.OnChangeListener sliderListener = (slider, value, fromUser) -> updateColor.run();
+        hueSlider.addOnChangeListener(sliderListener);
+        satSlider.addOnChangeListener(sliderListener);
+        valSlider.addOnChangeListener(sliderListener);
+        alphaSlider.addOnChangeListener(sliderListener);
         hexInput.addTextChangedListener(new android.text.TextWatcher() {
             @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
             @Override public void onTextChanged(CharSequence s, int start, int before, int count) {}
@@ -1396,10 +1387,10 @@ public class PhotoEditorPlugin extends Plugin {
                         currentColor[0] = c;
                         boxBg.setColor(c);
                         Color.colorToHSV(c, hsv);
-                        hueSlider.setProgress((int) hsv[0]);
-                        satSlider.setProgress((int) (hsv[1] * 100));
-                        valSlider.setProgress((int) (hsv[2] * 100));
-                        alphaSlider.setProgress(Color.alpha(c));
+                        hueSlider.setValue((int) hsv[0]);
+                        satSlider.setValue((int) (hsv[1] * 100));
+                        valSlider.setValue((int) (hsv[2] * 100));
+                        alphaSlider.setValue(Color.alpha(c));
                     } catch (Exception ignored) {}
                 }
             }
@@ -1795,20 +1786,15 @@ public class PhotoEditorPlugin extends Plugin {
         sizeLabel.setText("Size " + (int) currentTextSize[0]);
         sizeLabel.setTextColor(Color.parseColor("#b5bac1"));
         sizeLabel.setTextSize(14f);
+        sizeLabel.setGravity(Gravity.END | Gravity.CENTER_VERTICAL);
         sizeLabel.setMinimumWidth(dp(65)); // Prevent layout jumping
         styleRow.addView(sizeLabel);
         
-        android.widget.SeekBar sizeSlider = new android.widget.SeekBar(context);
-        sizeSlider.setMax(110); // 10 to 120
-        sizeSlider.setProgress((int) currentTextSize[0] - 10);
-        sizeSlider.setOnSeekBarChangeListener(new android.widget.SeekBar.OnSeekBarChangeListener() {
-            @Override public void onProgressChanged(android.widget.SeekBar seekBar, int progress, boolean fromUser) {
-                currentTextSize[0] = progress + 10f;
-                sizeLabel.setText("Size " + (int) currentTextSize[0]);
-                updateTypeface.run();
-            }
-            @Override public void onStartTrackingTouch(android.widget.SeekBar seekBar) {}
-            @Override public void onStopTrackingTouch(android.widget.SeekBar seekBar) {}
+        com.google.android.material.slider.Slider sizeSlider = PhotoEditorUi.createDiscordSlider(context, 0, 110, currentTextSize[0] - 10);
+        sizeSlider.addOnChangeListener((slider, value, fromUser) -> {
+            currentTextSize[0] = Math.round(value) + 10f;
+            sizeLabel.setText("Size " + (int) currentTextSize[0]);
+            updateTypeface.run();
         });
         LinearLayout.LayoutParams sliderParams = new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
         styleRow.addView(sizeSlider, sliderParams);
@@ -2439,21 +2425,14 @@ public class PhotoEditorPlugin extends Plugin {
             degreeLabel.setGravity(Gravity.CENTER);
             sliderRow.addView(degreeLabel);
 
-            android.widget.SeekBar rotateSlider = new android.widget.SeekBar(context);
-            rotateSlider.setMax(360);
-            rotateSlider.setProgress(180);
+            com.google.android.material.slider.Slider rotateSlider = PhotoEditorUi.createDiscordSlider(context, 0, 360, 180);
             rotateSlider.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
-            rotateSlider.setOnSeekBarChangeListener(new android.widget.SeekBar.OnSeekBarChangeListener() {
-                @Override
-                public void onProgressChanged(android.widget.SeekBar seekBar, int progress, boolean fromUser) {
-                    if (fromUser) {
-                        rotation[0] = progress - 180f;
-                        degreeLabel.setText((int)rotation[0] + "°");
-                        updatePreview.run();
-                    }
+            rotateSlider.addOnChangeListener((slider, value, fromUser) -> {
+                if (fromUser) {
+                    rotation[0] = value - 180f;
+                    degreeLabel.setText((int) rotation[0] + "°");
+                    updatePreview.run();
                 }
-                @Override public void onStartTrackingTouch(android.widget.SeekBar seekBar) {}
-                @Override public void onStopTrackingTouch(android.widget.SeekBar seekBar) {}
             });
             sliderRow.addView(rotateSlider);
             rotateControls.addView(sliderRow);
@@ -2479,7 +2458,7 @@ public class PhotoEditorPlugin extends Plugin {
                 float newRot = rotation[0] + 90f;
                 if (newRot > 180f) newRot -= 360f;
                 rotation[0] = newRot;
-                rotateSlider.setProgress((int)newRot + 180);
+                rotateSlider.setValue((int)newRot + 180);
                 degreeLabel.setText((int)newRot + "°");
                 updatePreview.run();
             });
@@ -2842,6 +2821,7 @@ public class PhotoEditorPlugin extends Plugin {
     }
 
     private void addManualOverlay(PhotoEditorView editorView, View overlay) {
+        overlayRedoStack.clear();
         Runnable add = () -> {
             if (overlay.getParent() == null) {
                 ViewGroup.LayoutParams existing = overlay.getLayoutParams();
@@ -3130,6 +3110,7 @@ public class PhotoEditorPlugin extends Plugin {
     }
 
     private void clearAllEditorOverlays(PhotoEditor editor, PhotoEditorView editorView) {
+        overlayRedoStack.clear();
         try {
             editor.clearAllViews();
         } catch (Throwable throwable) {
@@ -3621,26 +3602,20 @@ public class PhotoEditorPlugin extends Plugin {
             
             row.addView(header);
 
-            android.widget.SeekBar slider = new android.widget.SeekBar(context);
-            slider.setMax(200); // Normalize to 0-200
+            com.google.android.material.slider.Slider slider = PhotoEditorUi.createDiscordSlider(context, 0, 200, 0);
             
             float current = customFilterValues[i];
             float range = maxs[i] - mins[i];
             int progress = (int) (((current - mins[i]) / range) * 200f);
-            slider.setProgress(progress);
+            slider.setValue(progress);
 
-            slider.setOnSeekBarChangeListener(new android.widget.SeekBar.OnSeekBarChangeListener() {
-                @Override
-                public void onProgressChanged(android.widget.SeekBar seekBar, int prog, boolean fromUser) {
-                    if (fromUser) {
-                        float val = mins[index] + ((float) prog / 200f) * range;
-                        customFilterValues[index] = val;
-                        valueText.setText(String.format(java.util.Locale.US, "%.2f", val));
-                        updateFilter.run();
-                    }
+            slider.addOnChangeListener((view, value, fromUser) -> {
+                if (fromUser) {
+                    float val = mins[index] + (value / 200f) * range;
+                    customFilterValues[index] = val;
+                    valueText.setText(String.format(java.util.Locale.US, "%.2f", val));
+                    updateFilter.run();
                 }
-                @Override public void onStartTrackingTouch(android.widget.SeekBar seekBar) {}
-                @Override public void onStopTrackingTouch(android.widget.SeekBar seekBar) {}
             });
             row.addView(slider);
             content.addView(row);

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -311,7 +311,9 @@ public class PhotoEditorPlugin extends Plugin {
         final java.lang.reflect.Method[] undoRedoMethods = new java.lang.reflect.Method[2];
         try {
             undoRedoMethods[0] = editor.getClass().getDeclaredMethod("isUndoAvailable");
+            undoRedoMethods[0].setAccessible(true);
             undoRedoMethods[1] = editor.getClass().getDeclaredMethod("isRedoAvailable");
+            undoRedoMethods[1].setAccessible(true);
         } catch (Throwable ignored) {}
 
         Runnable stateUpdater = new Runnable() {
@@ -545,7 +547,7 @@ public class PhotoEditorPlugin extends Plugin {
 
         for (java.lang.reflect.Method method : StickerPickerViewModel.class.getDeclaredMethods()) {
             Class<?>[] paramTypes = method.getParameterTypes();
-            if (paramTypes.length >= 1 && (paramTypes[0] == Sticker.class || paramTypes[0] == Object.class)) {
+            if (paramTypes.length == 1 && (paramTypes[0] == Sticker.class || paramTypes[0] == Object.class)) {
                 Class<?> retType = method.getReturnType();
                 if (retType == boolean.class || retType == Boolean.class || retType == void.class) {
                     patcher.patch(method, new InsteadHook(callFrame -> {
@@ -1259,7 +1261,7 @@ public class PhotoEditorPlugin extends Plugin {
                 @Override
                 public boolean onTouch(View view, android.view.MotionEvent event) {
                     int action = event.getAction();
-                    if (action == android.view.MotionEvent.ACTION_DOWN || action == android.view.MotionEvent.ACTION_MOVE || action == android.view.MotionEvent.ACTION_UP) {
+                    if (action == android.view.MotionEvent.ACTION_DOWN || action == android.view.MotionEvent.ACTION_MOVE || action == android.view.MotionEvent.ACTION_UP || action == android.view.MotionEvent.ACTION_CANCEL) {
                         try {
                             android.widget.ImageView source = editorView.getSource();
                             android.graphics.drawable.BitmapDrawable drawable = (android.graphics.drawable.BitmapDrawable) source.getDrawable();
@@ -1281,7 +1283,7 @@ public class PhotoEditorPlugin extends Plugin {
                             // Silently ignore out of bounds during drag
                         }
                         
-                        if (action == android.view.MotionEvent.ACTION_UP) {
+                        if (action == android.view.MotionEvent.ACTION_UP || action == android.view.MotionEvent.ACTION_CANCEL) {
                             editorView.setOnTouchListener(null);
                             editor.setBrushDrawingMode(true);
                         }
@@ -2517,7 +2519,7 @@ public class PhotoEditorPlugin extends Plugin {
                     m.postRotate(rotation[0]);
                     if (flip[0]) m.postScale(-1, 1);
                     if (flip[1]) m.postScale(1, -1);
-                    Bitmap finalRotatedSrc = Bitmap.createBitmap(src, 0, 0, src.getWidth(), src.getHeight(), m, true);
+                    Bitmap finalRotatedSrc = (rotation[0] == 0f && !flip[0] && !flip[1]) ? src : Bitmap.createBitmap(src, 0, 0, src.getWidth(), src.getHeight(), m, true);
 
                     RectF percent = cropOverlay.getCropRectPercent();
                     int w = finalRotatedSrc.getWidth();

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -98,7 +98,7 @@ public class PhotoEditorPlugin extends Plugin {
         void onSpoilerToggled(boolean isSpoiler);
     }
 
-    private View createToolbar(Context context, PhotoEditor editor, PhotoEditorView editorView, Dialog dialog, Attachment<?>[] currentAttachment, EditRequest editRequest, PhotoFilter[] sessionFilter, boolean[] isCustomFilter, float[] customFilterValues) {
+    View createToolbar(Context context, PhotoEditor editor, PhotoEditorView editorView, Dialog dialog, Attachment<?>[] currentAttachment, EditRequest editRequest, PhotoFilter[] sessionFilter, boolean[] isCustomFilter, float[] customFilterValues) {
         LinearLayout rootContainer = new LinearLayout(context);
         rootContainer.setOrientation(LinearLayout.VERTICAL);
         rootContainer.setBackgroundColor(0xff1e1f22);
@@ -120,7 +120,7 @@ public class PhotoEditorPlugin extends Plugin {
         FrameLayout subToolbarContainer = new FrameLayout(context);
         subToolbarContainer.setVisibility(View.INVISIBLE);
         subToolbarContainer.setBackgroundColor(0xff2b2d31);
-        
+
         rootContainer.addView(subToolbarContainer, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 dp(64)
@@ -171,22 +171,22 @@ public class PhotoEditorPlugin extends Plugin {
         sliderContainer.setOrientation(LinearLayout.HORIZONTAL);
         sliderContainer.setGravity(Gravity.CENTER_VERTICAL);
         sliderContainer.setPadding(0, 0, dp(8), 0);
-        
+
         TextView sizeLabel = new TextView(context);
         sizeLabel.setTextColor(Color.WHITE);
         sizeLabel.setTextSize(14f);
         sizeLabel.setGravity(Gravity.END | Gravity.CENTER_VERTICAL);
-        
+
         // initialize label text with current brushSize
         sizeLabel.setSingleLine(true);
         sizeLabel.setText(brushSize + " px");
-        
+
         sizeLabel.setPadding(dp(8), 0, dp(4), 0);
         sliderContainer.addView(sizeLabel, new LinearLayout.LayoutParams(dp(60), ViewGroup.LayoutParams.WRAP_CONTENT));
 
         com.google.android.material.slider.Slider brushSlider = PhotoEditorUi.createDiscordSlider(context, 0, 75, brushSize - 5);
         brushSlider.setPadding(dp(8), 0, dp(8), 0);
-        
+
         brushSlider.addOnChangeListener((slider, value, fromUser) -> {
             int newSize = Math.round(value) + 5;
             brushSize = newSize;
@@ -194,7 +194,7 @@ public class PhotoEditorPlugin extends Plugin {
             editor.setBrushSize((float) newSize);
             editor.setBrushEraserSize((float) newSize);
         });
-        
+
         sliderContainer.addView(brushSlider, new LinearLayout.LayoutParams(dp(130), ViewGroup.LayoutParams.WRAP_CONTENT));
         drawToolbar.addView(sliderContainer);
 
@@ -202,7 +202,7 @@ public class PhotoEditorPlugin extends Plugin {
 
         final View currentColorBtn = colorSwatch(context, brushColor, null);
         currentColorBtn.setOnClickListener(v -> {
-            showColorPickerDialog(context, editorView, editor, brushColor, newColor -> {
+            PhotoEditorColorPicker.show(context, editorView, editor, brushColor, COLORS, newColor -> {
                 brushColor = newColor;
                 textColor = newColor;
                 setColorSwatchSelected(currentColorBtn, newColor, true);
@@ -227,7 +227,7 @@ public class PhotoEditorPlugin extends Plugin {
         ));
 
         for (PhotoFilter filter : FILTERS) {
-            View fBtn = iconButton(context, humanize(filter.name()), null, null);
+            View fBtn = iconButton(context, PhotoEditorUtils.humanize(filter.name()), null, null);
             fBtn.setTag(filter);
             filterButtons.add(fBtn);
             fBtn.setOnClickListener(v -> {
@@ -250,7 +250,7 @@ public class PhotoEditorPlugin extends Plugin {
                     Toast.makeText(context, "This filter requires Android 7.0+ to save properly", Toast.LENGTH_LONG).show();
             });
             filterToolbar.addView(fBtn);
-            
+
             if (filter == PhotoFilter.NONE) {
                 View customBtn = iconButton(context, "Custom", null, null);
                 customBtn.setTag("CUSTOM");
@@ -261,7 +261,7 @@ public class PhotoEditorPlugin extends Plugin {
                     editor.setFilterEffect(PhotoFilter.NONE);
                     sessionFilter[0] = PhotoFilter.NONE;
                     selectedFilter = PhotoFilter.NONE;
-                    showCustomFilterDialog(context, editorView, customFilterValues);
+                    PhotoEditorFilterDialog.show(context, editorView, settings, customFilterValues);
                 });
                 filterToolbar.addView(customBtn);
             }
@@ -302,7 +302,7 @@ public class PhotoEditorPlugin extends Plugin {
             @Override
             public void run() {
                 if (undoMainBtn.getParent() == null) return;
-                
+
                 boolean hasOverlay = false;
                 for (int i = 0; i < editorView.getChildCount(); i++) {
                     View child = editorView.getChildAt(i);
@@ -312,14 +312,14 @@ public class PhotoEditorPlugin extends Plugin {
                         break;
                     }
                 }
-                
+
                 boolean canUndo = editor.isUndoAvailable();
                 boolean canRedo = editor.isRedoAvailable() || !overlayRedoStack.isEmpty();
-                
+
                 boolean undoActive = hasOverlay || canUndo;
                 boolean redoActive = canRedo;
                 boolean clearActive = hasOverlay || canUndo || canRedo;
-                
+
                 if (undoMainBtn instanceof android.view.ViewGroup && ((android.view.ViewGroup) undoMainBtn).getChildCount() > 0) {
                     ((android.view.ViewGroup) undoMainBtn).getChildAt(0).setAlpha(undoActive ? 1f : 0.3f);
                 }
@@ -360,7 +360,7 @@ public class PhotoEditorPlugin extends Plugin {
             selectOnly(mainButtons, null);
             subToolbarContainer.setVisibility(View.INVISIBLE);
             editor.setBrushDrawingMode(false);
-            showTextDialog(context, editor, editorView);
+            PhotoEditorTextDialog.show(this, context, editor, editorView);
         });
         mainToolbar.addView(textMainBtn);
 
@@ -384,7 +384,7 @@ public class PhotoEditorPlugin extends Plugin {
             selectOnly(mainButtons, null);
             subToolbarContainer.setVisibility(View.INVISIBLE);
             editor.setBrushDrawingMode(false);
-            showImagePicker(context, editor, editorView);
+            PhotoEditorImagePicker.show(this, context, editor, editorView);
         });
         mainToolbar.addView(imageMainBtn);
 
@@ -392,7 +392,7 @@ public class PhotoEditorPlugin extends Plugin {
             selectOnly(mainButtons, null);
             subToolbarContainer.setVisibility(View.INVISIBLE);
             editor.setBrushDrawingMode(false);
-            showCropDialog(context, editorView.getSource(), editorView);
+            PhotoEditorCropDialog.show(this, context, editorView.getSource(), editorView);
         });
         mainToolbar.addView(cropMainBtn);
 
@@ -430,12 +430,12 @@ public class PhotoEditorPlugin extends Plugin {
         return rootContainer;
     }
 
-    private static final String OVERLAY_TEXT = "photoeditor:text";
-    private static final String OVERLAY_EMOJI = "photoeditor:emoji";
-    private static final String OVERLAY_IMAGE = "photoeditor:image";
+    static final String OVERLAY_TEXT = "photoeditor:text";
+    static final String OVERLAY_EMOJI = "photoeditor:emoji";
+    static final String OVERLAY_IMAGE = "photoeditor:image";
     private static final String MEDIA_EDIT_BUTTON_TAG = "photoeditor:media-edit-button";
 
-    private static final int[] COLORS = {
+    static final int[] COLORS = {
             Color.WHITE,
             Color.BLACK,
             0xffef4444,
@@ -478,6 +478,10 @@ public class PhotoEditorPlugin extends Plugin {
     private WeakReference<WidgetChatInputAttachments> latestChatInputAttachments = new WeakReference<>(null);
     private WeakReference<SelectionAggregator<?>> latestAggregator = new WeakReference<>(null);
     private boolean editorStickerPickerOpen;
+
+    void setEditorStickerPickerOpen(boolean open) {
+        editorStickerPickerOpen = open;
+    }
     private int brushColor = Color.WHITE;
     private int textColor = Color.WHITE;
     private int brushSize = 24;
@@ -498,10 +502,10 @@ public class PhotoEditorPlugin extends Plugin {
                     latestAggregator = new WeakReference<>(aggregator);
                     registerEditRequest(aggregator, attachment);
 
-                    FragmentActivity activity = findFragmentActivity(getRealActivity());
+                    FragmentActivity activity = findFragmentActivity(Utils.getAppActivity());
                     if (settings.getBool("quick_edit", false) && activity != null && isLikelyImage(attachment)) {
                         EditRequest editReq = editRequests.get(attachment);
-                        com.aliucord.Utils.mainThread.postDelayed(() -> openEditor(activity, attachment, editReq, aggregator), 160);
+                        com.aliucord.Utils.mainThread.postDelayed(() -> PhotoEditorSession.open(this, activity, attachment, editReq, aggregator), 160);
                         return null;
                     }
                     try {
@@ -687,7 +691,7 @@ public class PhotoEditorPlugin extends Plugin {
     private void openSentImageEditor(Context context, SentImageContext sentImageContext) {
         FragmentActivity activity = findFragmentActivity(context);
         if (activity == null)
-            activity = findFragmentActivity(getRealActivity());
+            activity = findFragmentActivity(Utils.getAppActivity());
         if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
             Toast.makeText(context, "Could not open image editor", Toast.LENGTH_SHORT).show();
             return;
@@ -705,7 +709,7 @@ public class PhotoEditorPlugin extends Plugin {
                         null,
                         false
                 );
-                Utils.mainThread.post(() -> openEditor(finalActivity, attachment, (oldAttachment, newAttachment) -> addEditedReplyAttachment(finalActivity, sentImageContext.message, newAttachment), null));
+                Utils.mainThread.post(() -> PhotoEditorSession.open(this, finalActivity, attachment, (oldAttachment, newAttachment) -> addEditedReplyAttachment(finalActivity, sentImageContext.message, newAttachment), null));
             } catch (Throwable throwable) {
                 logger.error("Failed to download sent image for editing", throwable);
                 Utils.mainThread.post(() -> Toast.makeText(context, "Failed to load image for editing", Toast.LENGTH_SHORT).show());
@@ -718,7 +722,7 @@ public class PhotoEditorPlugin extends Plugin {
         if (!dir.exists() && !dir.mkdirs())
             dir = context.getCacheDir();
 
-        String displayName = editedFileName(sentImageContext.displayName).replace("-edited-", "-source-");
+        String displayName = PhotoEditorUtils.editedFileName(sentImageContext.displayName).replace("-edited-", "-source-");
         File output = new File(dir, displayName);
         try (InputStream input = new java.net.URL(sentImageContext.url).openConnection().getInputStream();
              FileOutputStream outputStream = new FileOutputStream(output, false)) {
@@ -792,7 +796,7 @@ public class PhotoEditorPlugin extends Plugin {
             edit.setOnClickListener(view -> {
                 FragmentActivity activity = findFragmentActivity(view.getContext());
                 sheet.dismiss();
-                com.aliucord.Utils.mainThread.postDelayed(() -> openEditor(activity, attachment, editRequest, latestAggregator.get()), 160);
+                com.aliucord.Utils.mainThread.postDelayed(() -> PhotoEditorSession.open(this, activity, attachment, editRequest, latestAggregator.get()), 160);
             });
 
             ConstraintLayout.LayoutParams params = new ConstraintLayout.LayoutParams(
@@ -819,302 +823,6 @@ public class PhotoEditorPlugin extends Plugin {
         return remove != null && remove.getParent() instanceof ViewGroup ? (ViewGroup) remove.getParent() : null;
     }
 
-    private Activity getRealActivity() {
-        try {
-            Class<?> activityThreadClass = Class.forName("android.app.ActivityThread");
-            Object activityThread = activityThreadClass.getMethod("currentActivityThread").invoke(null);
-            java.lang.reflect.Field activitiesField = activityThreadClass.getDeclaredField("mActivities");
-            activitiesField.setAccessible(true);
-            java.util.Map<?, ?> activities = (java.util.Map<?, ?>) activitiesField.get(activityThread);
-            
-            for (Object activityRecord : activities.values()) {
-                java.lang.reflect.Field activityField = activityRecord.getClass().getDeclaredField("activity");
-                activityField.setAccessible(true);
-                Activity activity = (Activity) activityField.get(activityRecord);
-                if (activity != null && !activity.isFinishing() && (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.JELLY_BEAN_MR1 || !activity.isDestroyed())) {
-                    return activity;
-                }
-            }
-        } catch (Throwable t) {
-            logger.error("Failed to get active activity from ActivityThread", t);
-        }
-        return com.aliucord.Utils.getAppActivity();
-    }
-
-    private void openEditor(Activity passedActivity, Attachment<?> attachment, EditRequest editRequest, SelectionAggregator<?> aggregator) {
-        final Activity activity;
-        if (passedActivity == null || passedActivity.isFinishing() || (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1 && passedActivity.isDestroyed())) {
-            activity = getRealActivity();
-        } else {
-            activity = passedActivity;
-        }
-        if (activity == null || activity.isFinishing() || (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1 && activity.isDestroyed())) {
-            android.widget.Toast.makeText(getRealActivity(), "Could not open image editor (activity null or destroyed)", android.widget.Toast.LENGTH_SHORT).show();
-            return;
-        }
-        if (attachment.getUri() == null) {
-            android.widget.Toast.makeText(activity, "Attachment has no URI", android.widget.Toast.LENGTH_SHORT).show();
-            return;
-        }
-
-        Dialog dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar_Fullscreen);
-
-        PhotoEditorView editorView = new PhotoEditorView(activity);
-        PhotoEditor editor = new PhotoEditor.Builder(activity, editorView)
-                .setPinchTextScalable(true)
-                .setClipSourceImage(false)
-                .build();
-
-        final Attachment<?>[] currentAttachment = {attachment};
-        final PhotoFilter[] sessionFilter = {PhotoFilter.NONE};
-        final boolean[] isCustomFilter = {false};
-        final float[] customFilterValues = new float[]{0f, 1f, 1f, 0f, 0f, 0f}; // Brightness, Contrast, Saturation, Hue, Temp, Tint
-
-        FrameLayout spoilerOverlay = new FrameLayout(activity);
-        spoilerOverlay.setBackgroundColor(0x99000000);
-        
-        TextView spoilerText = new TextView(activity);
-        spoilerText.setText("SPOILER");
-        spoilerText.setTextColor(Color.WHITE);
-        spoilerText.setTextSize(24f);
-        spoilerText.setTypeface(null, android.graphics.Typeface.BOLD);
-        spoilerText.setPadding(dp(20), dp(8), dp(20), dp(8));
-        
-        android.graphics.drawable.GradientDrawable pill = new android.graphics.drawable.GradientDrawable();
-        pill.setColor(0x80000000);
-        pill.setCornerRadius(dp(20));
-        spoilerText.setBackground(pill);
-        
-        spoilerOverlay.addView(spoilerText, new FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-                Gravity.CENTER
-        ));
-        spoilerOverlay.setVisibility(attachment.getSpoiler() ? View.VISIBLE : View.GONE);
-
-        FrameLayout root = new FrameLayout(activity) {
-            @Override
-            public boolean dispatchTouchEvent(android.view.MotionEvent ev) {
-                if (ev.getAction() == android.view.MotionEvent.ACTION_DOWN) {
-                    if (spoilerOverlay.getVisibility() == View.VISIBLE && spoilerOverlay.getAlpha() == 1f) {
-                        spoilerOverlay.animate().alpha(0f).setDuration(150).withEndAction(() -> {
-                            spoilerOverlay.setVisibility(View.GONE);
-                            spoilerOverlay.setAlpha(1f);
-                        }).start();
-                    }
-                }
-                return super.dispatchTouchEvent(ev);
-            }
-        };
-        root.setBackgroundColor(0xff111214);
-
-        LinearLayout content = new LinearLayout(activity);
-        content.setOrientation(LinearLayout.VERTICAL);
-        root.addView(content, new FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-        ));
-
-        View header = createHeader(activity, currentAttachment, aggregator, view -> dialog.dismiss(), isSpoiler -> {
-            if (isSpoiler) {
-                spoilerOverlay.setVisibility(View.VISIBLE);
-                spoilerOverlay.setAlpha(0f);
-                spoilerOverlay.animate().alpha(1f).setDuration(150).setListener(null).start();
-            } else {
-                if (spoilerOverlay.getVisibility() == View.VISIBLE) {
-                    spoilerOverlay.animate().alpha(0f).setDuration(150).withEndAction(() -> {
-                        spoilerOverlay.setVisibility(View.GONE);
-                        spoilerOverlay.setAlpha(1f);
-                    }).start();
-                }
-            }
-        });
-        
-        android.widget.ImageView saveBtn = new android.widget.ImageView(activity);
-        int saveId = Utils.getResId("ic_check_white_24dp", "drawable");
-        saveBtn.setImageResource(saveId != 0 ? saveId : android.R.drawable.ic_menu_save);
-        saveBtn.setColorFilter(Color.WHITE);
-        saveBtn.setPadding(dp(8), dp(8), dp(8), dp(8));
-        addRippleBorderless(saveBtn);
-        addPressAnimation(saveBtn);
-        saveBtn.setOnClickListener(v -> saveImage(activity, editor, editorView, currentAttachment, editRequest, dialog, sessionFilter, isCustomFilter, customFilterValues));
-        
-        LinearLayout.LayoutParams saveParams = new LinearLayout.LayoutParams(dp(40), dp(40));
-        saveParams.setMargins(dp(8), 0, 0, 0);
-        ((LinearLayout) header).addView(saveBtn, saveParams);
-
-        content.addView(header, new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        ));
-
-        FrameLayout editorHolder = new FrameLayout(activity);
-        editorHolder.setBackgroundColor(Color.BLACK);
-        content.addView(editorHolder, new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                0,
-                1f
-        ));
-
-        editorHolder.addView(editorView, new FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                Gravity.CENTER
-        ));
-
-        editorHolder.addView(spoilerOverlay, new FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-        ));
-
-        ProgressBar progressBar = new ProgressBar(activity);
-        editorHolder.addView(progressBar, new FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-                Gravity.CENTER
-        ));
-
-        content.addView(createToolbar(activity, editor, editorView, dialog, currentAttachment, editRequest, sessionFilter, isCustomFilter, customFilterValues), new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        ));
-
-        dialog.setContentView(root);
-        Window window = dialog.getWindow();
-        if (window != null) {
-            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
-            window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
-        }
-
-        dialog.setOnShowListener(ignored -> {
-            Window shownWindow = dialog.getWindow();
-            if (shownWindow != null)
-                shownWindow.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
-            loadImage(currentAttachment[0].getUri(), editorView, editorHolder, progressBar);
-            applyBrush(editor);
-        });
-        dialog.setOnDismissListener(ignored -> {
-            editorStickerPickerOpen = false;
-        });
-
-        try {
-            editorStickerPickerOpen = true;
-            dialog.show();
-        } catch (android.view.WindowManager.BadTokenException badTokenException) {
-            editorStickerPickerOpen = false;
-            logger.error("Failed to show PhotoEditor dialog because the activity window token is invalid", badTokenException);
-            Toast.makeText(activity, "Could not open image editor", Toast.LENGTH_SHORT).show();
-        }
-    }
-
-    private View createHeader(Context context, Attachment<?>[] currentAttachment, SelectionAggregator<?> aggregator, View.OnClickListener onClose, SpoilerToggleListener spoilerListener) {
-        LinearLayout header = new LinearLayout(context);
-        header.setOrientation(LinearLayout.HORIZONTAL);
-        header.setGravity(Gravity.CENTER_VERTICAL);
-        header.setBackgroundColor(0xff1e1f22);
-        header.setPadding(dp(16), dp(10), dp(16), dp(10));
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            header.setElevation(dp(4));
-        }
-
-        android.widget.ImageView closeBtn = new android.widget.ImageView(context);
-        int closeId = Utils.getResId("ic_close_24dp", "drawable");
-        closeBtn.setImageResource(closeId != 0 ? closeId : android.R.drawable.ic_menu_close_clear_cancel);
-        closeBtn.setColorFilter(Color.WHITE);
-        closeBtn.setPadding(dp(8), dp(8), dp(8), dp(8));
-        closeBtn.setOnClickListener(onClose);
-        addRippleBorderless(closeBtn);
-        addPressAnimation(closeBtn);
-
-        LinearLayout.LayoutParams closeParams = new LinearLayout.LayoutParams(dp(40), dp(40));
-        closeParams.setMargins(0, 0, dp(8), 0);
-        closeBtn.setLayoutParams(closeParams);
-        header.addView(closeBtn);
-
-        TextView title = new TextView(context);
-        String displayName = currentAttachment[0].getDisplayName();
-        title.setText(displayName == null ? "PhotoEditor" : displayName);
-        title.setTextColor(Color.WHITE);
-        title.setTextSize(16f);
-        title.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
-        title.setSingleLine(true);
-        title.setEllipsize(android.text.TextUtils.TruncateAt.END);
-        LinearLayout.LayoutParams titleParams = new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
-        title.setLayoutParams(titleParams);
-        header.addView(title);
-
-        if (aggregator != null) {
-            // Spoiler toggle
-            android.widget.ImageView spoilerBtn = new android.widget.ImageView(context);
-            int eyeOpenId = Utils.getResId("ic_eye_24dp", "drawable");
-            int eyeClosedId = Utils.getResId("ic_eye_closed_24dp", "drawable");
-            if (eyeOpenId == 0) eyeOpenId = android.R.drawable.ic_menu_view;
-            if (eyeClosedId == 0) eyeClosedId = android.R.drawable.ic_menu_view;
-
-            boolean[] isSpoiler = {currentAttachment[0].getSpoiler()};
-            spoilerBtn.setImageResource(isSpoiler[0] ? eyeClosedId : eyeOpenId);
-            spoilerBtn.setColorFilter(isSpoiler[0] ? 0xffda373c : Color.WHITE);
-            spoilerBtn.setPadding(dp(8), dp(8), dp(8), dp(8));
-            addRippleBorderless(spoilerBtn);
-            addPressAnimation(spoilerBtn);
-            
-            final int finalEyeOpen = eyeOpenId;
-            final int finalEyeClosed = eyeClosedId;
-
-            spoilerBtn.setOnClickListener(v -> {
-                isSpoiler[0] = !isSpoiler[0];
-                spoilerBtn.setImageResource(isSpoiler[0] ? finalEyeClosed : finalEyeOpen);
-                spoilerBtn.setColorFilter(isSpoiler[0] ? 0xffda373c : Color.WHITE);
-                
-                try {
-                    Attachment<?> edited = new Attachment<>(
-                            currentAttachment[0].getId(),
-                            currentAttachment[0].getUri(),
-                            currentAttachment[0].getDisplayName(),
-                            null,
-                            isSpoiler[0]
-                    );
-                    replaceAttachment(aggregator, currentAttachment[0], edited);
-                    currentAttachment[0] = edited;
-                    if (spoilerListener != null) {
-                        spoilerListener.onSpoilerToggled(isSpoiler[0]);
-                    }
-                } catch (Throwable t) {
-                    logger.error("Failed to toggle spoiler", t);
-                }
-            });
-
-            LinearLayout.LayoutParams spoilerParams = new LinearLayout.LayoutParams(dp(40), dp(40));
-            spoilerParams.setMargins(0, 0, dp(8), 0);
-            header.addView(spoilerBtn, spoilerParams);
-
-            // Delete button
-            android.widget.ImageView deleteBtn = new android.widget.ImageView(context);
-            int deleteId = Utils.getResId("ic_delete_24dp", "drawable");
-            deleteBtn.setImageResource(deleteId != 0 ? deleteId : android.R.drawable.ic_menu_delete);
-            deleteBtn.setColorFilter(0xffda373c);
-            deleteBtn.setPadding(dp(8), dp(8), dp(8), dp(8));
-            addRippleBorderless(deleteBtn);
-            addPressAnimation(deleteBtn);
-
-            deleteBtn.setOnClickListener(v -> {
-                try {
-                    java.lang.reflect.Method remove = SelectionAggregator.class.getDeclaredMethod("removeItem", Attachment.class);
-                    remove.setAccessible(true);
-                    remove.invoke(aggregator, currentAttachment[0]);
-                    onClose.onClick(v);
-                } catch (Throwable t) {
-                    logger.error("Failed to delete attachment", t);
-                }
-            });
-
-            LinearLayout.LayoutParams deleteParams = new LinearLayout.LayoutParams(dp(40), dp(40));
-            header.addView(deleteBtn, deleteParams);
-        }
-
-        return header;
-    }
-
     private View groupSeparator(Context context) {
         View sep = new View(context);
         sep.setBackgroundColor(0xff3f4147);
@@ -1124,7 +832,7 @@ public class PhotoEditorPlugin extends Plugin {
         return sep;
     }
 
-    private View iconButton(Context context, String label, String drawableName, View.OnClickListener listener) {
+    View iconButton(Context context, String label, String drawableName, View.OnClickListener listener) {
         int resId = 0;
         if (drawableName != null) {
             resId = Utils.getResId(drawableName, "drawable");
@@ -1179,7 +887,7 @@ public class PhotoEditorPlugin extends Plugin {
 
 
 
-    private View colorSwatch(Context context, int color, View.OnClickListener listener) {
+    View colorSwatch(Context context, int color, View.OnClickListener listener) {
         View swatch = new View(context);
         setColorSwatchSelected(swatch, color, color == brushColor);
         swatch.setOnClickListener(listener);
@@ -1189,234 +897,6 @@ public class PhotoEditorPlugin extends Plugin {
         params.setMargins(0, 0, dp(8), 0);
         swatch.setLayoutParams(params);
         return swatch;
-    }
-    
-    interface ColorCallback {
-        void onColorPicked(int color);
-    }
-    
-    private void showColorPickerDialog(Context context, PhotoEditorView editorView, PhotoEditor editor, int initialColor, ColorCallback callback) {
-        Dialog dialog = new Dialog(context);
-        
-        LinearLayout root = new LinearLayout(context);
-        root.setOrientation(LinearLayout.VERTICAL);
-        root.setPadding(dp(20), dp(20), dp(20), dp(20));
-        
-        android.graphics.drawable.GradientDrawable rootBg = new android.graphics.drawable.GradientDrawable();
-        rootBg.setColor(0xff2b2d31);
-        rootBg.setCornerRadius(dp(16));
-        root.setBackground(rootBg);
-        
-        // 1. Title Row (Title + Eyedropper)
-        LinearLayout titleRow = new LinearLayout(context);
-        titleRow.setOrientation(LinearLayout.HORIZONTAL);
-        titleRow.setGravity(Gravity.CENTER_VERTICAL);
-        
-        TextView title = new TextView(context);
-        title.setText("Custom Color");
-        title.setTextColor(Color.WHITE);
-        title.setTextSize(18f);
-        title.setTypeface(null, android.graphics.Typeface.BOLD);
-        titleRow.addView(title, new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
-        
-        android.widget.ImageView eyedropper = new android.widget.ImageView(context);
-        int dropperId = Utils.getResId("ic_colorize_24dp", "drawable");
-        if (dropperId == 0) dropperId = Utils.getResId("ic_edit_24dp", "drawable");
-        eyedropper.setImageResource(dropperId);
-        eyedropper.setColorFilter(Color.WHITE);
-        eyedropper.setPadding(dp(8), dp(8), dp(8), dp(8));
-        addRippleBorderless(eyedropper);
-        titleRow.addView(eyedropper);
-        root.addView(titleRow);
-
-        // Eyedropper Logic
-        eyedropper.setOnClickListener(v -> {
-            dialog.dismiss();
-            android.widget.Toast.makeText(context, "Tap anywhere on the image to pick a color!", android.widget.Toast.LENGTH_SHORT).show();
-            
-            editor.setBrushDrawingMode(false);
-            editorView.setOnTouchListener(new View.OnTouchListener() {
-                @Override
-                public boolean onTouch(View view, android.view.MotionEvent event) {
-                    int action = event.getAction();
-                    if (action == android.view.MotionEvent.ACTION_DOWN || action == android.view.MotionEvent.ACTION_MOVE || action == android.view.MotionEvent.ACTION_UP || action == android.view.MotionEvent.ACTION_CANCEL) {
-                        try {
-                            android.widget.ImageView source = editorView.getSource();
-                            android.graphics.drawable.BitmapDrawable drawable = (android.graphics.drawable.BitmapDrawable) source.getDrawable();
-                            android.graphics.Bitmap bitmap = drawable.getBitmap();
-                            
-                            android.graphics.Matrix inverse = new android.graphics.Matrix();
-                            source.getImageMatrix().invert(inverse);
-                            float[] pts = {event.getX(), event.getY()};
-                            inverse.mapPoints(pts);
-                            
-                            int x = (int) pts[0];
-                            int y = (int) pts[1];
-                            
-                            if (x >= 0 && y >= 0 && x < bitmap.getWidth() && y < bitmap.getHeight()) {
-                                int pixel = bitmap.getPixel(x, y);
-                                callback.onColorPicked(pixel);
-                            }
-                        } catch (Throwable t) {
-                            // Silently ignore out of bounds during drag
-                        }
-                        
-                        if (action == android.view.MotionEvent.ACTION_UP || action == android.view.MotionEvent.ACTION_CANCEL) {
-                            editorView.setOnTouchListener(null);
-                            editor.setBrushDrawingMode(true);
-                        }
-                        return true;
-                    }
-                    return false;
-                }
-            });
-        });
-        
-        // 2. Preview Box and HEX
-        LinearLayout previewRow = new LinearLayout(context);
-        previewRow.setOrientation(LinearLayout.HORIZONTAL);
-        previewRow.setGravity(Gravity.CENTER_VERTICAL);
-        previewRow.setPadding(0, dp(16), 0, dp(16));
-        
-        View previewBox = new View(context);
-        android.graphics.drawable.GradientDrawable boxBg = new android.graphics.drawable.GradientDrawable();
-        boxBg.setCornerRadius(dp(8));
-        boxBg.setColor(initialColor);
-        previewBox.setBackground(boxBg);
-        previewRow.addView(previewBox, new LinearLayout.LayoutParams(dp(48), dp(48)));
-        
-        android.widget.EditText hexInput = new android.widget.EditText(context);
-        hexInput.setTextColor(Color.WHITE);
-        hexInput.setText(String.format("#%08X", initialColor));
-        hexInput.setSingleLine(true);
-        LinearLayout.LayoutParams hexParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        hexParams.setMargins(dp(16), 0, 0, 0);
-        previewRow.addView(hexInput, hexParams);
-        root.addView(previewRow);
-
-        
-        // 3. HSV Sliders
-        float[] hsv = new float[3];
-        Color.colorToHSV(initialColor, hsv);
-        
-        TextView hueLabel = new TextView(context); hueLabel.setText("Hue"); hueLabel.setTextColor(Color.LTGRAY); root.addView(hueLabel);
-        com.google.android.material.slider.Slider hueSlider = PhotoEditorUi.createDiscordSlider(context, 0, 360, hsv[0]); root.addView(hueSlider);
-        
-        TextView satLabel = new TextView(context); satLabel.setText("Saturation"); satLabel.setTextColor(Color.LTGRAY); satLabel.setPadding(0, dp(8), 0, 0); root.addView(satLabel);
-        com.google.android.material.slider.Slider satSlider = PhotoEditorUi.createDiscordSlider(context, 0, 100, hsv[1] * 100); root.addView(satSlider);
-        
-        TextView valLabel = new TextView(context); valLabel.setText("Lightness"); valLabel.setTextColor(Color.LTGRAY); valLabel.setPadding(0, dp(8), 0, 0); root.addView(valLabel);
-        com.google.android.material.slider.Slider valSlider = PhotoEditorUi.createDiscordSlider(context, 0, 100, hsv[2] * 100); root.addView(valSlider);
-        
-        final android.widget.ImageView colorPlane = new android.widget.ImageView(context);
-        int colorPlaneSize = dp(180);
-        colorPlane.setImageBitmap(PhotoEditorUi.createColorPlane(colorPlaneSize));
-        colorPlane.setScaleType(android.widget.ImageView.ScaleType.FIT_XY);
-        root.addView(colorPlane, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, colorPlaneSize));
-        colorPlane.setVisibility(View.GONE);
-        previewBox.setOnClickListener(v -> colorPlane.setVisibility(colorPlane.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE));
-        TextView alphaLabel = new TextView(context); alphaLabel.setText("Opacity"); alphaLabel.setTextColor(Color.LTGRAY); alphaLabel.setPadding(0, dp(8), 0, 0); root.addView(alphaLabel);
-        com.google.android.material.slider.Slider alphaSlider = PhotoEditorUi.createDiscordSlider(context, 0, 255, Color.alpha(initialColor)); root.addView(alphaSlider);
-        
-        // 4. Presets Horizontal Scroll
-        android.widget.HorizontalScrollView presetScroll = new android.widget.HorizontalScrollView(context);
-        presetScroll.setHorizontalScrollBarEnabled(false);
-        LinearLayout presetContainer = new LinearLayout(context);
-        presetContainer.setOrientation(LinearLayout.HORIZONTAL);
-        presetContainer.setPadding(0, dp(16), 0, dp(16));
-        for (int c : COLORS) {
-            View swatch = new View(context);
-            android.graphics.drawable.GradientDrawable swBg = new android.graphics.drawable.GradientDrawable();
-            swBg.setCornerRadius(dp(16)); swBg.setColor(c);
-            swatch.setBackground(swBg);
-            LinearLayout.LayoutParams swParams = new LinearLayout.LayoutParams(dp(32), dp(32));
-            swParams.setMargins(0, 0, dp(8), 0);
-            swatch.setLayoutParams(swParams);
-            swatch.setOnClickListener(v -> {
-                Color.colorToHSV(c, hsv);
-                hueSlider.setValue((int) hsv[0]);
-                satSlider.setValue((int) (hsv[1] * 100));
-                valSlider.setValue((int) (hsv[2] * 100));
-                alphaSlider.setValue(Color.alpha(c));
-            });
-            presetContainer.addView(swatch);
-        }
-        presetScroll.addView(presetContainer);
-        root.addView(presetScroll);
-        
-        // Updates
-        final int[] currentColor = {initialColor};
-        
-        Runnable updateColor = () -> {
-            try {
-                hsv[0] = hueSlider.getValue();
-                hsv[1] = satSlider.getValue() / 100f;
-                hsv[2] = valSlider.getValue() / 100f;
-                int alpha = Math.round(alphaSlider.getValue());
-                currentColor[0] = Color.HSVToColor(alpha, hsv);
-                boxBg.setColor(currentColor[0]);
-                previewBox.invalidate();
-                if (!hexInput.hasFocus()) {
-                    hexInput.setText(String.format("#%08X", currentColor[0]));
-                }
-            } catch (Exception e) {}
-        };
-        
-        colorPlane.setOnTouchListener((v, event) -> {
-            float hue = Math.max(0f, Math.min(360f, event.getX() / Math.max(1f, v.getWidth()) * 360f));
-            float position = Math.max(0f, Math.min(1f, event.getY() / Math.max(1f, v.getHeight())));
-            float saturation = position <= 0.5f ? position * 2f : 1f;
-            float value = position <= 0.5f ? 1f : (1f - position) * 2f;
-            hueSlider.setValue(Math.round(hue));
-            satSlider.setValue(Math.round(saturation * 100f));
-            valSlider.setValue(Math.round(value * 100f));
-            return true;
-        });
-        com.google.android.material.slider.Slider.OnChangeListener sliderListener = (slider, value, fromUser) -> updateColor.run();
-        hueSlider.addOnChangeListener(sliderListener);
-        satSlider.addOnChangeListener(sliderListener);
-        valSlider.addOnChangeListener(sliderListener);
-        alphaSlider.addOnChangeListener(sliderListener);
-        hexInput.addTextChangedListener(new android.text.TextWatcher() {
-            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
-            @Override public void onTextChanged(CharSequence s, int start, int before, int count) {}
-            @Override public void afterTextChanged(android.text.Editable s) {
-                if (hexInput.hasFocus() && s.toString().startsWith("#")) {
-                    try {
-                        int c = Color.parseColor(s.toString());
-                        currentColor[0] = c;
-                        boxBg.setColor(c);
-                        Color.colorToHSV(c, hsv);
-                        hueSlider.setValue((int) hsv[0]);
-                        satSlider.setValue((int) (hsv[1] * 100));
-                        valSlider.setValue((int) (hsv[2] * 100));
-                        alphaSlider.setValue(Color.alpha(c));
-                    } catch (Exception ignored) {}
-                }
-            }
-        });
-        
-        // Buttons
-        LinearLayout btnRow = new LinearLayout(context);
-        btnRow.setOrientation(LinearLayout.HORIZONTAL);
-        btnRow.setGravity(Gravity.RIGHT);
-        
-        TextView cancel = new TextView(context); cancel.setText("Cancel"); cancel.setTextColor(Color.GRAY); cancel.setPadding(dp(16), dp(8), dp(16), dp(8));
-        cancel.setOnClickListener(v -> dialog.dismiss());
-        btnRow.addView(cancel);
-        
-        TextView apply = new TextView(context); apply.setText("Select"); apply.setTextColor(0xff5865f2); apply.setPadding(dp(16), dp(8), dp(16), dp(8)); apply.setTypeface(null, android.graphics.Typeface.BOLD);
-        apply.setOnClickListener(v -> {
-            callback.onColorPicked(currentColor[0]);
-            dialog.dismiss();
-        });
-        btnRow.addView(apply);
-        
-        root.addView(btnRow);
-        
-        dialog.setContentView(root);
-        dialog.getWindow().setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(Color.TRANSPARENT));
-        dialog.show();
     }
 
     private void setToolbarButtonSelected(View button, boolean selected) {
@@ -1444,12 +924,12 @@ public class PhotoEditorPlugin extends Plugin {
         }
     }
 
-    private void setColorSwatchSelected(View swatch, int color, boolean selected) {
+    void setColorSwatchSelected(View swatch, int color, boolean selected) {
         android.graphics.drawable.GradientDrawable drawable = new android.graphics.drawable.GradientDrawable();
         drawable.setShape(android.graphics.drawable.GradientDrawable.OVAL);
         drawable.setColor(color);
         drawable.setStroke(dp(selected ? 3 : 1), selected ? Color.WHITE : Color.parseColor("#4e5058"));
-        
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             android.content.res.ColorStateList rippleColor = android.content.res.ColorStateList.valueOf(0x40ffffff);
             android.graphics.drawable.RippleDrawable ripple = new android.graphics.drawable.RippleDrawable(rippleColor, drawable, null);
@@ -1464,7 +944,7 @@ public class PhotoEditorPlugin extends Plugin {
             setToolbarButtonSelected(button, button == selected);
     }
 
-    private void selectColorOnly(List<View> swatches, int selectedColor) {
+    void selectColorOnly(List<View> swatches, int selectedColor) {
         for (View swatch : swatches) {
             Object tag = swatch.getTag();
             if (tag instanceof Integer)
@@ -1472,7 +952,7 @@ public class PhotoEditorPlugin extends Plugin {
         }
     }
 
-    private Dialog customDialog(Context context, String titleText, View customView) {
+    Dialog customDialog(Context context, String titleText, View customView) {
         Dialog dialog = new Dialog(context);
         dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
 
@@ -1516,404 +996,26 @@ public class PhotoEditorPlugin extends Plugin {
         return dialog;
     }
 
-    private void showImagePicker(Context context, PhotoEditor editor, PhotoEditorView editorView) {
-        androidx.fragment.app.FragmentActivity activity = findFragmentActivity(context);
-        if (activity == null) activity = findFragmentActivity(getRealActivity());
-        if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
-            android.widget.Toast.makeText(context, "Could not open image picker", android.widget.Toast.LENGTH_SHORT).show();
-            return;
-        }
-
-        ImagePickerFragment fragment = new ImagePickerFragment();
-        fragment.setListener(uri -> {
-            if (uri != null) {
-                com.aliucord.Utils.threadPool.execute(() -> {
-                    try {
-                        android.graphics.Bitmap bmp = android.provider.MediaStore.Images.Media.getBitmap(context.getContentResolver(), uri);
-                        if (bmp != null) {
-                            com.aliucord.Utils.mainThread.post(() -> addBitmapOverlay(editorView, bmp));
-                        }
-                    } catch (Throwable t) {
-                        logger.error("Failed to load picked image", t);
-                        com.aliucord.Utils.mainThread.post(() -> android.widget.Toast.makeText(context, "Failed to load image", android.widget.Toast.LENGTH_SHORT).show());
-                    }
-                });
-            }
-        });
-
-        activity.getSupportFragmentManager().beginTransaction().add(fragment, "IMAGE_PICKER").commitAllowingStateLoss();
-    }
-
     // showFilterDialog removed because it is now rendered inline within the toolbar
 
     /** Returns true for filters that rely purely on GL shaders and have no ColorMatrix equivalent. */
-    private boolean isGlOnlyFilter(PhotoFilter filter) {
+    com.aliucord.api.SettingsAPI getSettings() { return settings; }
+
+    boolean isGlOnlyFilter(PhotoFilter filter) {
         return filter == PhotoFilter.GRAIN
             || filter == PhotoFilter.FISH_EYE
             || filter == PhotoFilter.VIGNETTE
             || filter == PhotoFilter.SHARPEN;
     }
 
-    private void showTextDialog(Context context, PhotoEditor editor, PhotoEditorView editorView) {
-        Dialog dialog = new Dialog(context);
-        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+    int getTextColor() { return textColor; }
+    void setTextColor(int color) { textColor = color; }
 
-        LinearLayout layout = createBottomSheetContainer(context);
-        
-        // State variables
-        final int[] currentTextColor = {textColor};
-        final float[] currentTextSize = {28f};
-        final String[] currentFontFamily = {"sans-serif"};
-        final boolean[] isBold = {false};
-        final boolean[] isItalic = {false};
-        final boolean[] isUnderlined = {false};
-        final android.graphics.Typeface[] finalTypeface = {android.graphics.Typeface.DEFAULT};
-
-        final java.util.Map<String, String> fontPathMap = new java.util.HashMap<>();
-        String[] defaultFonts = {"sans-serif", "sans-serif-thin", "sans-serif-light", "sans-serif-medium", "sans-serif-black", "sans-serif-condensed", "sans-serif-condensed-light", "sans-serif-condensed-medium", "serif", "monospace", "serif-monospace", "casual", "cursive", "sans-serif-smallcaps"};
-        final java.util.List<String> fontList = new java.util.ArrayList<>(java.util.Arrays.asList(defaultFonts));
-        
-        class FontScanner {
-            void scan(java.io.File dir, int depth) {
-                if (depth > 2 || dir == null || !dir.exists() || !dir.isDirectory()) return;
-                java.io.File[] files = dir.listFiles();
-                if (files != null) {
-                    for (java.io.File f : files) {
-                        if (f.isDirectory()) {
-                            scan(f, depth + 1);
-                        } else if (f.isFile() && (f.getName().endsWith(".ttf") || f.getName().endsWith(".otf"))) {
-                            String name = f.getName();
-                            String cleanName = name.substring(0, name.lastIndexOf('.'));
-                            fontList.add(cleanName);
-                            fontPathMap.put(cleanName, f.getAbsolutePath());
-                        }
-                    }
-                }
-            }
-        }
-        new FontScanner().scan(new java.io.File("/system/fonts"), 0);
-        new FontScanner().scan(new java.io.File(Environment.getExternalStorageDirectory(), "Fonts"), 0);
-        new FontScanner().scan(new java.io.File(Environment.getExternalStorageDirectory(), "Aliucord/fonts"), 0);
-
-        EditText input = dialogInput(context, "Enter your text...");
-        android.graphics.drawable.GradientDrawable inputBg = new android.graphics.drawable.GradientDrawable();
-        inputBg.setColor(0xff1e1f22);
-        inputBg.setCornerRadius(dp(8));
-        inputBg.setStroke(dp(1), Color.parseColor("#3f4147"));
-        input.setBackground(inputBg);
-        input.setTextColor(currentTextColor[0]);
-        input.setHintTextColor(Color.parseColor("#80848e"));
-        input.setTextSize(currentTextSize[0]);
-        input.setMinLines(2);
-        input.setGravity(Gravity.TOP | Gravity.START);
-        input.setPadding(dp(12), dp(12), dp(12), dp(12));
-
-        Runnable updateTypeface = () -> {
-            int style = android.graphics.Typeface.NORMAL;
-            if (isBold[0] && isItalic[0]) style = android.graphics.Typeface.BOLD_ITALIC;
-            else if (isBold[0]) style = android.graphics.Typeface.BOLD;
-            else if (isItalic[0]) style = android.graphics.Typeface.ITALIC;
-            
-            try {
-                if (fontPathMap.containsKey(currentFontFamily[0])) {
-                    java.io.File f = new java.io.File(fontPathMap.get(currentFontFamily[0]));
-                    if (f.exists()) {
-                        finalTypeface[0] = android.graphics.Typeface.createFromFile(f);
-                        if (style != android.graphics.Typeface.NORMAL) {
-                            finalTypeface[0] = android.graphics.Typeface.create(finalTypeface[0], style);
-                        }
-                    } else {
-                        finalTypeface[0] = android.graphics.Typeface.create(currentFontFamily[0], style);
-                    }
-                } else if (currentFontFamily[0].endsWith(".ttf") || currentFontFamily[0].endsWith(".otf")) {
-                    java.io.File f = new java.io.File("/system/fonts/" + currentFontFamily[0]);
-                    if (f.exists()) {
-                        finalTypeface[0] = android.graphics.Typeface.createFromFile(f);
-                        if (style != android.graphics.Typeface.NORMAL) {
-                            finalTypeface[0] = android.graphics.Typeface.create(finalTypeface[0], style);
-                        }
-                    } else {
-                        finalTypeface[0] = android.graphics.Typeface.create(currentFontFamily[0], style);
-                    }
-                } else {
-                    finalTypeface[0] = android.graphics.Typeface.create(currentFontFamily[0], style);
-                }
-            } catch (Exception e) {
-                finalTypeface[0] = android.graphics.Typeface.create("sans-serif", style);
-            }
-            input.setTypeface(finalTypeface[0]);
-            input.setTextSize(currentTextSize[0]);
-            input.setTextColor(currentTextColor[0]);
-            
-            if (isUnderlined[0]) {
-                input.setPaintFlags(input.getPaintFlags() | android.graphics.Paint.UNDERLINE_TEXT_FLAG);
-            } else {
-                input.setPaintFlags(input.getPaintFlags() & ~android.graphics.Paint.UNDERLINE_TEXT_FLAG);
-            }
-        };
-
-        LinearLayout.LayoutParams inputParams = new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        );
-        inputParams.setMargins(0, 0, 0, dp(16));
-        input.setLayoutParams(inputParams);
-        layout.addView(input);
-        
-        // Wrap everything else in a ScrollView to prevent keyboard overlap
-        android.widget.ScrollView scrollView = new android.widget.ScrollView(context);
-        LinearLayout scrollContent = new LinearLayout(context);
-        scrollContent.setOrientation(LinearLayout.VERTICAL);
-        
-        // Font Selection Row
-        android.widget.AutoCompleteTextView fontSearch = new android.widget.AutoCompleteTextView(context);
-        
-        int bgColor = 0xff313338;
-        int textColorPrimary = Color.WHITE;
-        try {
-            android.util.TypedValue typedValue = new android.util.TypedValue();
-            int bgAttr = Utils.getResId("colorBackgroundFloating", "attr");
-            if (bgAttr != 0 && context.getTheme().resolveAttribute(bgAttr, typedValue, true)) {
-                bgColor = typedValue.data;
-            } else if (context.getTheme().resolveAttribute(android.R.attr.windowBackground, typedValue, true)) {
-                bgColor = typedValue.data;
-            }
-            
-            int textAttr = Utils.getResId("colorTextNormal", "attr");
-            if (textAttr != 0 && context.getTheme().resolveAttribute(textAttr, typedValue, true)) {
-                textColorPrimary = typedValue.data;
-            } else if (context.getTheme().resolveAttribute(android.R.attr.textColorPrimary, typedValue, true)) {
-                textColorPrimary = typedValue.data;
-            }
-        } catch (Exception ignored) {}
-        final int finalTextColor = textColorPrimary;
-        
-        fontSearch.setTextColor(textColorPrimary);
-        fontSearch.setHint("Search font (e.g., sans-serif)");
-        fontSearch.setHintTextColor(Color.GRAY);
-        fontSearch.setSingleLine(true);
-        fontSearch.setText("sans-serif");
-        fontSearch.setThreshold(0); // Show dropdown even when empty
-        fontSearch.setDropDownHeight(dp(150)); // Constrain height so it doesn't hide behind keyboard
-        fontSearch.setDropDownBackgroundDrawable(new android.graphics.drawable.ColorDrawable(bgColor)); // Match theme
-        fontSearch.setOnClickListener(v -> fontSearch.showDropDown());
-        fontSearch.setOnFocusChangeListener((v, hasFocus) -> { if (hasFocus) fontSearch.showDropDown(); });
-        android.widget.ArrayAdapter<String> adapter = new android.widget.ArrayAdapter<String>(context, android.R.layout.simple_dropdown_item_1line, fontList) {
-            @Override
-            public View getView(int position, View convertView, ViewGroup parent) {
-                TextView view = (TextView) super.getView(position, convertView, parent);
-                view.setTextColor(finalTextColor);
-                return view;
-            }
-        };
-        fontSearch.setAdapter(adapter);
-        
-        fontSearch.addTextChangedListener(new android.text.TextWatcher() {
-            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
-            @Override public void onTextChanged(CharSequence s, int start, int before, int count) {}
-            @Override public void afterTextChanged(android.text.Editable s) {
-                currentFontFamily[0] = s.toString().trim();
-                updateTypeface.run();
-            }
-        });
-        fontSearch.setOnItemClickListener((parent, view, position, id) -> {
-            currentFontFamily[0] = adapter.getItem(position);
-            updateTypeface.run();
-        });
-        
-        LinearLayout.LayoutParams searchParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        searchParams.setMargins(0, 0, 0, dp(12));
-        scrollContent.addView(fontSearch, searchParams);
-        
-        // Style Toggles Row
-        LinearLayout styleTogglesRow = new LinearLayout(context);
-        styleTogglesRow.setOrientation(LinearLayout.HORIZONTAL);
-        styleTogglesRow.setGravity(Gravity.START | Gravity.CENTER_VERTICAL);
-        
-        // Bold Toggle
-        TextView boldToggle = new TextView(context);
-        boldToggle.setText("B");
-        boldToggle.setTextColor(Color.GRAY);
-        boldToggle.setTextSize(18f);
-        boldToggle.setTypeface(null, android.graphics.Typeface.BOLD);
-        boldToggle.setPadding(dp(8), dp(4), dp(16), dp(4));
-        boldToggle.setOnClickListener(v -> {
-            isBold[0] = !isBold[0];
-            boldToggle.setTextColor(isBold[0] ? Color.WHITE : Color.GRAY);
-            updateTypeface.run();
-        });
-        styleTogglesRow.addView(boldToggle);
-        
-        // Italic Toggle
-        TextView italicToggle = new TextView(context);
-        italicToggle.setText("I");
-        italicToggle.setTextColor(Color.GRAY);
-        italicToggle.setTextSize(18f);
-        italicToggle.setTypeface(null, android.graphics.Typeface.ITALIC);
-        italicToggle.setPadding(dp(16), dp(4), dp(16), dp(4));
-        italicToggle.setOnClickListener(v -> {
-            isItalic[0] = !isItalic[0];
-            italicToggle.setTextColor(isItalic[0] ? Color.WHITE : Color.GRAY);
-            updateTypeface.run();
-        });
-        styleTogglesRow.addView(italicToggle);
-
-        // Underline Toggle
-        TextView underlineToggle = new TextView(context);
-        underlineToggle.setText("U");
-        underlineToggle.setTextColor(Color.GRAY);
-        underlineToggle.setTextSize(18f);
-        underlineToggle.setPaintFlags(underlineToggle.getPaintFlags() | android.graphics.Paint.UNDERLINE_TEXT_FLAG);
-        underlineToggle.setPadding(dp(16), dp(4), dp(16), dp(4));
-        underlineToggle.setOnClickListener(v -> {
-            isUnderlined[0] = !isUnderlined[0];
-            underlineToggle.setTextColor(isUnderlined[0] ? Color.WHITE : Color.GRAY);
-            updateTypeface.run();
-        });
-        styleTogglesRow.addView(underlineToggle);
-        
-        LinearLayout.LayoutParams togglesRowParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        togglesRowParams.setMargins(0, 0, 0, dp(12));
-        scrollContent.addView(styleTogglesRow, togglesRowParams);
-        
-        // Size & Color Row
-        LinearLayout styleRow = new LinearLayout(context);
-        styleRow.setOrientation(LinearLayout.HORIZONTAL);
-        styleRow.setGravity(Gravity.CENTER_VERTICAL);
-        styleRow.setPadding(0, 0, 0, dp(16));
-        
-        TextView sizeLabel = new TextView(context);
-        sizeLabel.setText("Size " + (int) currentTextSize[0]);
-        sizeLabel.setTextColor(Color.parseColor("#b5bac1"));
-        sizeLabel.setTextSize(14f);
-        sizeLabel.setGravity(Gravity.END | Gravity.CENTER_VERTICAL);
-        sizeLabel.setMinimumWidth(dp(65)); // Prevent layout jumping
-        styleRow.addView(sizeLabel);
-        
-        com.google.android.material.slider.Slider sizeSlider = PhotoEditorUi.createDiscordSlider(context, 0, 110, currentTextSize[0] - 10);
-        sizeSlider.addOnChangeListener((slider, value, fromUser) -> {
-            currentTextSize[0] = Math.round(value) + 10f;
-            sizeLabel.setText("Size " + (int) currentTextSize[0]);
-            updateTypeface.run();
-        });
-        LinearLayout.LayoutParams sliderParams = new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
-        styleRow.addView(sizeSlider, sliderParams);
-        
-        View colorBtn = colorSwatch(context, currentTextColor[0], null);
-        colorBtn.setOnClickListener(v -> {
-            showColorPickerDialog(context, editorView, editor, currentTextColor[0], newColor -> {
-                currentTextColor[0] = newColor;
-                textColor = newColor; // Also sync global text color
-                setColorSwatchSelected(colorBtn, newColor, true);
-                updateTypeface.run();
-            });
-        });
-        LinearLayout.LayoutParams colorBtnParams = new LinearLayout.LayoutParams(dp(32), dp(32));
-        colorBtnParams.setMargins(dp(12), 0, 0, 0);
-        colorBtn.setLayoutParams(colorBtnParams);
-        styleRow.addView(colorBtn);
-        
-        scrollContent.addView(styleRow);
-        
-        scrollView.addView(scrollContent);
-        LinearLayout.LayoutParams scrollParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        // We use weight=1f so that if the keyboard pushes it, it shrinks and becomes scrollable
-        scrollParams.weight = 1f;
-        layout.addView(scrollView, scrollParams);
-
-        updateTypeface.run();
-
-        // Buttons
-        LinearLayout buttons = new LinearLayout(context);
-        buttons.setOrientation(LinearLayout.HORIZONTAL);
-        buttons.setGravity(Gravity.RIGHT);
-
-        TextView cancelBtn = new TextView(context);
-        cancelBtn.setText("Cancel");
-        cancelBtn.setTextColor(Color.parseColor("#dbdee1"));
-        cancelBtn.setTextSize(14f);
-        cancelBtn.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
-        cancelBtn.setGravity(Gravity.CENTER);
-        cancelBtn.setPadding(dp(16), dp(11), dp(16), dp(11));
-        cancelBtn.setOnClickListener(v -> dialog.dismiss());
-        buttons.addView(cancelBtn);
-
-        TextView addBtn = new TextView(context);
-        addBtn.setText("Add");
-        addBtn.setTextColor(Color.WHITE);
-        addBtn.setTextSize(14f);
-        addBtn.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
-        addBtn.setGravity(Gravity.CENTER);
-        addBtn.setPadding(dp(18), dp(11), dp(18), dp(11));
-
-        android.graphics.drawable.GradientDrawable addBg = new android.graphics.drawable.GradientDrawable();
-        addBg.setColor(0xff5865f2);
-        addBg.setCornerRadius(dp(8));
-        addBtn.setBackground(addBg);
-
-        addBtn.setOnClickListener(v -> {
-            String text = input.getText().toString().trim();
-            if (!text.isEmpty()) {
-                try {
-                    editor.setBrushDrawingMode(false);
-                    addTextOverlay(editorView, text, currentTextColor[0], finalTypeface[0], currentTextSize[0], isUnderlined[0]);
-                } catch (Throwable t) {
-                    logger.error("Failed to add text to canvas", t);
-                    android.widget.Toast.makeText(context, "Failed to add text: " + t.getMessage(), android.widget.Toast.LENGTH_LONG).show();
-                }
-            }
-            dialog.dismiss();
-        });
-
-        LinearLayout.LayoutParams addParams = new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        );
-        addParams.setMargins(dp(8), 0, 0, 0);
-        addBtn.setLayoutParams(addParams);
-        buttons.addView(addBtn);
-
-        layout.addView(buttons);
-
-        dialog.setContentView(layout);
-        Window window = dialog.getWindow();
-        if (window != null) {
-            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
-            window.setGravity(Gravity.BOTTOM);
-            window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        }
-        dialog.setOnShowListener(ignored -> {
-            Window shownWindow = dialog.getWindow();
-            if (shownWindow != null) {
-                shownWindow.setGravity(Gravity.TOP | Gravity.CENTER_HORIZONTAL);
-                WindowManager.LayoutParams attributes = shownWindow.getAttributes();
-                attributes.y = dp(72);
-                shownWindow.setAttributes(attributes);
-                shownWindow.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-                shownWindow.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE | WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
-            }
-            input.requestFocus();
-        });
-        Window dialogWindow = dialog.getWindow();
-        if (dialogWindow != null)
-            dialogWindow.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE | WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
-        dialog.show();
-    }
-
-    private ja.burhanrashid52.photoeditor.TextStyleBuilder textStyle(int color, float sizeSp) {
-        ja.burhanrashid52.photoeditor.TextStyleBuilder builder = new ja.burhanrashid52.photoeditor.TextStyleBuilder();
-        builder.withTextColor(color);
-        builder.withTextSize(sizeSp);
-        builder.withGravity(Gravity.CENTER);
-        builder.withTextShadow(dp(1), dp(1), dp(2), 0xcc000000);
-        return builder;
-    }
-
-    private LinearLayout createBottomSheetContainer(Context context) {
+    LinearLayout createBottomSheetContainer(Context context) {
         return createBottomSheetContainer(context, "Add Text");
     }
 
-    private LinearLayout createBottomSheetContainer(Context context, String titleText) {
+    LinearLayout createBottomSheetContainer(Context context, String titleText) {
         LinearLayout root = new LinearLayout(context);
         root.setOrientation(LinearLayout.VERTICAL);
         root.setPadding(dp(16), dp(10), dp(16), dp(16));
@@ -1947,7 +1049,7 @@ public class PhotoEditorPlugin extends Plugin {
         return root;
     }
 
-    private void showKeyboardDialog(Dialog dialog, View content, EditText input) {
+    void showKeyboardDialog(Dialog dialog, View content, EditText input) {
         dialog.setContentView(content);
         Window window = dialog.getWindow();
         if (window != null) {
@@ -1976,7 +1078,7 @@ public class PhotoEditorPlugin extends Plugin {
     private void showDiscordEmojiPicker(Context context, PhotoEditor editor, PhotoEditorView editorView) {
         FragmentActivity activity = findFragmentActivity(context);
         if (activity == null)
-            activity = findFragmentActivity(getRealActivity());
+            activity = findFragmentActivity(Utils.getAppActivity());
 
         if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
             Toast.makeText(context, "Could not open Discord emoji picker", Toast.LENGTH_SHORT).show();
@@ -2005,7 +1107,7 @@ public class PhotoEditorPlugin extends Plugin {
     private void showDiscordStickerPicker(Context context, PhotoEditor editor, PhotoEditorView editorView) {
         FragmentActivity activity = findFragmentActivity(context);
         if (activity == null)
-            activity = findFragmentActivity(getRealActivity());
+            activity = findFragmentActivity(Utils.getAppActivity());
 
         if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
             Toast.makeText(context, "Could not open Discord sticker picker", Toast.LENGTH_SHORT).show();
@@ -2036,7 +1138,7 @@ public class PhotoEditorPlugin extends Plugin {
         }
     }
 
-    private FragmentActivity findFragmentActivity(Context context) {
+    FragmentActivity findFragmentActivity(Context context) {
         Context current = context;
         while (current instanceof ContextWrapper) {
             if (current instanceof FragmentActivity)
@@ -2139,149 +1241,7 @@ public class PhotoEditorPlugin extends Plugin {
         }
     }
 
-    public static class CropOverlayView extends android.view.View {
-        private final Paint maskPaint = new Paint();
-        private final Paint borderPaint = new Paint();
-        private final Paint handlePaint = new Paint();
-        private final RectF cropRect = new RectF();
-        private final float handleRadius = DimenUtils.dpToPx(8);
-        private int activeHandle = -1; // 0: TL, 1: TR, 2: BL, 3: BR, 4: Center/Move
-        private float lastX, lastY;
-
-        public CropOverlayView(Context context) {
-            super(context);
-            maskPaint.setColor(0xaa000000); // 66% opacity dark mask
-            maskPaint.setStyle(Paint.Style.FILL);
-
-            borderPaint.setColor(Color.WHITE);
-            borderPaint.setStyle(Paint.Style.STROKE);
-            borderPaint.setStrokeWidth(DimenUtils.dpToPx(2));
-
-            handlePaint.setColor(Color.WHITE);
-            handlePaint.setStyle(Paint.Style.FILL);
-        }
-
-        @Override
-        protected void onSizeChanged(int w, int h, int oldw, int oldh) {
-            super.onSizeChanged(w, h, oldw, oldh);
-            float marginX = w * 0.1f;
-            float marginY = h * 0.1f;
-            cropRect.set(marginX, marginY, w - marginX, h - marginY);
-        }
-
-        @Override
-        protected void onDraw(Canvas canvas) {
-            super.onDraw(canvas);
-            int w = getWidth();
-            int h = getHeight();
-
-            // Draw dark mask outside crop area
-            canvas.drawRect(0, 0, w, cropRect.top, maskPaint);
-            canvas.drawRect(0, cropRect.bottom, w, h, maskPaint);
-            canvas.drawRect(0, cropRect.top, cropRect.left, cropRect.bottom, maskPaint);
-            canvas.drawRect(cropRect.right, cropRect.top, w, cropRect.bottom, maskPaint);
-
-            // Draw crop border
-            canvas.drawRect(cropRect, borderPaint);
-
-            // Draw handles at 4 corners
-            canvas.drawCircle(cropRect.left, cropRect.top, handleRadius, handlePaint);
-            canvas.drawCircle(cropRect.right, cropRect.top, handleRadius, handlePaint);
-            canvas.drawCircle(cropRect.left, cropRect.bottom, handleRadius, handlePaint);
-            canvas.drawCircle(cropRect.right, cropRect.bottom, handleRadius, handlePaint);
-        }
-
-        @Override
-        @SuppressLint("ClickableViewAccessibility")
-        public boolean onTouchEvent(MotionEvent event) {
-            float x = event.getX();
-            float y = event.getY();
-
-            switch (event.getAction()) {
-                case MotionEvent.ACTION_DOWN:
-                    lastX = x;
-                    lastY = y;
-                    activeHandle = getTouchedHandle(x, y);
-                    return activeHandle != -1;
-
-                case MotionEvent.ACTION_MOVE:
-                    if (activeHandle != -1) {
-                        float dx = x - lastX;
-                        float dy = y - lastY;
-                        moveHandle(activeHandle, dx, dy);
-                        lastX = x;
-                        lastY = y;
-                        invalidate();
-                        return true;
-                    }
-                    break;
-
-                case MotionEvent.ACTION_UP:
-                case MotionEvent.ACTION_CANCEL:
-                    activeHandle = -1;
-                    break;
-            }
-            return super.onTouchEvent(event);
-        }
-
-        private int getTouchedHandle(float x, float y) {
-            float touchTreshold = handleRadius * 2.5f;
-            if (distance(x, y, cropRect.left, cropRect.top) < touchTreshold) return 0; // TL
-            if (distance(x, y, cropRect.right, cropRect.top) < touchTreshold) return 1; // TR
-            if (distance(x, y, cropRect.left, cropRect.bottom) < touchTreshold) return 2; // BL
-            if (distance(x, y, cropRect.right, cropRect.bottom) < touchTreshold) return 3; // BR
-            if (cropRect.contains(x, y)) return 4; // Center
-            return -1;
-        }
-
-        private void moveHandle(int handle, float dx, float dy) {
-            float minSize = handleRadius * 4;
-            int w = getWidth();
-            int h = getHeight();
-
-            if (handle == 4) { // Move whole cropRect
-                if (cropRect.left + dx >= 0 && cropRect.right + dx <= w) {
-                    cropRect.left += dx;
-                    cropRect.right += dx;
-                }
-                if (cropRect.top + dy >= 0 && cropRect.bottom + dy <= h) {
-                    cropRect.top += dy;
-                    cropRect.bottom += dy;
-                }
-                return;
-            }
-
-            float newLeft = cropRect.left;
-            float newRight = cropRect.right;
-            float newTop = cropRect.top;
-            float newBottom = cropRect.bottom;
-
-            if (handle == 0 || handle == 2) newLeft = Math.max(0, Math.min(cropRect.right - minSize, cropRect.left + dx));
-            if (handle == 1 || handle == 3) newRight = Math.min(w, Math.max(cropRect.left + minSize, cropRect.right + dx));
-            if (handle == 0 || handle == 1) newTop = Math.max(0, Math.min(cropRect.bottom - minSize, cropRect.top + dy));
-            if (handle == 2 || handle == 3) newBottom = Math.min(h, Math.max(cropRect.top + minSize, cropRect.bottom + dy));
-
-            cropRect.set(newLeft, newTop, newRight, newBottom);
-        }
-
-        private float distance(float x1, float y1, float x2, float y2) {
-            return (float) Math.sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
-        }
-
-        public RectF getCropRectPercent() {
-            int w = getWidth();
-            int h = getHeight();
-            if (w == 0 || h == 0) return new RectF(0.1f, 0.1f, 0.9f, 0.9f);
-            return new RectF(
-                    cropRect.left / w,
-                    cropRect.top / h,
-                    cropRect.right / w,
-                    cropRect.bottom / h
-            );
-        }
-    }
-
-    private void fitEditorToBitmap(PhotoEditorView editorView, View editorHolder, Bitmap bitmap) {
+    void fitEditorToBitmap(PhotoEditorView editorView, View editorHolder, Bitmap bitmap) {
         if (bitmap == null || bitmap.getWidth() <= 0 || bitmap.getHeight() <= 0)
             return;
 
@@ -2323,237 +1283,7 @@ public class PhotoEditorPlugin extends Plugin {
         });
     }
 
-    private void showCropDialog(Context context, android.widget.ImageView targetView, PhotoEditorView editorView) {
-        try {
-            android.graphics.drawable.BitmapDrawable drawable = (android.graphics.drawable.BitmapDrawable) targetView.getDrawable();
-            if (drawable == null) {
-                Toast.makeText(context, "No image to crop", Toast.LENGTH_SHORT).show();
-                return;
-            }
-            Bitmap src = drawable.getBitmap();
-            if (src == null) {
-                Toast.makeText(context, "No bitmap to crop", Toast.LENGTH_SHORT).show();
-                return;
-            }
-
-            LinearLayout layout = new LinearLayout(context);
-            layout.setOrientation(LinearLayout.VERTICAL);
-
-            TextView info = new TextView(context);
-            info.setText("Drag corners to resize. Drag center to move crop area:");
-            info.setTextColor(Color.parseColor("#dbdee1"));
-            info.setTextSize(12f);
-            info.setPadding(0, 0, 0, dp(12));
-            layout.addView(info);
-
-            float[] rotation = {0f};
-            boolean[] flip = {false, false};
-            
-            // Create downscaled base for smooth preview dragging
-            int maxDim = Math.max(src.getWidth(), src.getHeight());
-            float downscale = maxDim > 800 ? 800f / maxDim : 1f;
-            Bitmap previewBase = downscale == 1f ? src : Bitmap.createScaledBitmap(src, (int)(src.getWidth() * downscale), (int)(src.getHeight() * downscale), true);
-
-            Bitmap[] currentPreview = {previewBase};
-
-            // Container for image and crop overlay
-            FrameLayout container = new FrameLayout(context) {
-                @Override
-                protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-                    int width = View.MeasureSpec.getSize(widthMeasureSpec);
-                    int height = (int) (width * ((float) currentPreview[0].getHeight() / currentPreview[0].getWidth()));
-                    int maxHeight = dp(350);
-                    if (height > maxHeight) {
-                        height = maxHeight;
-                        width = (int) (height * ((float) currentPreview[0].getWidth() / currentPreview[0].getHeight()));
-                    }
-                    int wSpec = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY);
-                    int hSpec = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY);
-                    super.onMeasure(wSpec, hSpec);
-                }
-            };
-            LinearLayout.LayoutParams containerParams = new LinearLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT
-            );
-            containerParams.setMargins(0, 0, 0, dp(16));
-            containerParams.gravity = Gravity.CENTER_HORIZONTAL;
-            container.setLayoutParams(containerParams);
-
-            android.widget.ImageView previewImage = new android.widget.ImageView(context);
-            previewImage.setImageBitmap(currentPreview[0]);
-            previewImage.setScaleType(android.widget.ImageView.ScaleType.FIT_XY);
-            container.addView(previewImage, new FrameLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.MATCH_PARENT
-            ));
-
-            CropOverlayView cropOverlay = new CropOverlayView(context);
-            container.addView(cropOverlay, new FrameLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.MATCH_PARENT
-            ));
-
-            layout.addView(container);
-
-            Runnable updatePreview = () -> {
-                android.graphics.Matrix m = new android.graphics.Matrix();
-                m.postRotate(rotation[0]);
-                if (flip[0]) m.postScale(-1, 1);
-                if (flip[1]) m.postScale(1, -1);
-                if (currentPreview[0] != null && currentPreview[0] != previewBase) {
-                    currentPreview[0].recycle();
-                }
-                currentPreview[0] = Bitmap.createBitmap(previewBase, 0, 0, previewBase.getWidth(), previewBase.getHeight(), m, true);
-                previewImage.setImageBitmap(currentPreview[0]);
-                container.requestLayout();
-            };
-
-            // Rotation Controls
-            LinearLayout rotateControls = new LinearLayout(context);
-            rotateControls.setOrientation(LinearLayout.VERTICAL);
-            rotateControls.setPadding(0, dp(8), 0, dp(16));
-
-            LinearLayout sliderRow = new LinearLayout(context);
-            sliderRow.setOrientation(LinearLayout.HORIZONTAL);
-            sliderRow.setGravity(Gravity.CENTER_VERTICAL);
-            
-            TextView degreeLabel = new TextView(context);
-            degreeLabel.setText("0°");
-            degreeLabel.setTextColor(Color.WHITE);
-            degreeLabel.setMinWidth(dp(40));
-            degreeLabel.setGravity(Gravity.CENTER);
-            sliderRow.addView(degreeLabel);
-
-            com.google.android.material.slider.Slider rotateSlider = PhotoEditorUi.createDiscordSlider(context, 0, 360, 180);
-            rotateSlider.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
-            rotateSlider.addOnChangeListener((slider, value, fromUser) -> {
-                if (fromUser) {
-                    rotation[0] = value - 180f;
-                    degreeLabel.setText((int) rotation[0] + "°");
-                    updatePreview.run();
-                }
-            });
-            sliderRow.addView(rotateSlider);
-            rotateControls.addView(sliderRow);
-
-            LinearLayout mirrorRow = new LinearLayout(context);
-            mirrorRow.setOrientation(LinearLayout.HORIZONTAL);
-            mirrorRow.setGravity(Gravity.CENTER);
-            mirrorRow.setPadding(0, dp(8), 0, 0);
-
-            View flipHBtn = iconButton(context, "Flip H", "ic_swap_horiz_24dp", v -> {
-                flip[0] = !flip[0];
-                updatePreview.run();
-            });
-            mirrorRow.addView(flipHBtn);
-
-            View flipVBtn = iconButton(context, "Flip V", "ic_swap_vert_24dp", v -> {
-                flip[1] = !flip[1];
-                updatePreview.run();
-            });
-            mirrorRow.addView(flipVBtn);
-
-            View rotate90Btn = iconButton(context, "Rotate 90°", "ucrop_ic_rotate", v -> {
-                float newRot = rotation[0] + 90f;
-                if (newRot > 180f) newRot -= 360f;
-                rotation[0] = newRot;
-                rotateSlider.setValue((int)newRot + 180);
-                degreeLabel.setText((int)newRot + "°");
-                updatePreview.run();
-            });
-            mirrorRow.addView(rotate90Btn);
-
-            rotateControls.addView(mirrorRow);
-            layout.addView(rotateControls);
-
-            Dialog dialog[] = new Dialog[1];
-
-            LinearLayout buttons = new LinearLayout(context);
-            buttons.setOrientation(LinearLayout.HORIZONTAL);
-            buttons.setGravity(Gravity.RIGHT);
-
-            TextView cancelBtn = new TextView(context);
-            cancelBtn.setText("Cancel");
-            cancelBtn.setTextColor(Color.parseColor("#dbdee1"));
-            cancelBtn.setPadding(dp(16), dp(10), dp(16), dp(10));
-            cancelBtn.setOnClickListener(v -> dialog[0].dismiss());
-            buttons.addView(cancelBtn);
-
-            TextView applyBtn = new TextView(context);
-            applyBtn.setText("Crop");
-            applyBtn.setTextColor(Color.WHITE);
-            applyBtn.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
-            applyBtn.setPadding(dp(16), dp(10), dp(16), dp(10));
-
-            android.graphics.drawable.GradientDrawable applyBg = new android.graphics.drawable.GradientDrawable();
-            applyBg.setColor(0xff5865f2);
-            applyBg.setCornerRadius(dp(6));
-            applyBtn.setBackground(applyBg);
-
-            applyBtn.setOnClickListener(v -> {
-                try {
-                    // 1. Generate full-res rotated bitmap
-                    android.graphics.Matrix m = new android.graphics.Matrix();
-                    m.postRotate(rotation[0]);
-                    if (flip[0]) m.postScale(-1, 1);
-                    if (flip[1]) m.postScale(1, -1);
-                    Bitmap finalRotatedSrc = (rotation[0] == 0f && !flip[0] && !flip[1]) ? src : Bitmap.createBitmap(src, 0, 0, src.getWidth(), src.getHeight(), m, true);
-
-                    RectF percent = cropOverlay.getCropRectPercent();
-                    int w = finalRotatedSrc.getWidth();
-                    int h = finalRotatedSrc.getHeight();
-
-                    int left = (int) (w * percent.left);
-                    int top = (int) (h * percent.top);
-                    int right = (int) (w * percent.right);
-                    int bottom = (int) (h * percent.bottom);
-
-                    int cropWidth = right - left;
-                    int cropHeight = bottom - top;
-
-                    if (cropWidth > 10 && cropHeight > 10) {
-                        Bitmap cropped = Bitmap.createBitmap(finalRotatedSrc, left, top, cropWidth, cropHeight);
-                        if (finalRotatedSrc != src) {
-                            finalRotatedSrc.recycle();
-                        }
-                        targetView.setScaleType(android.widget.ImageView.ScaleType.FIT_XY);
-                        targetView.setImageBitmap(cropped);
-                        
-                        if (targetView == editorView.getSource()) {
-                            fillEditorBaseLayers(editorView);
-                            if (editorView.getParent() instanceof View)
-                                fitEditorToBitmap(editorView, (View) editorView.getParent(), cropped);
-                        } else {
-                            targetView.requestLayout();
-                        }
-                        Toast.makeText(context, "Cropped successfully", Toast.LENGTH_SHORT).show();
-                    }
-                } catch (Throwable e) {
-                    logger.error(e);
-                    Toast.makeText(context, "Crop failed: " + e.getMessage(), Toast.LENGTH_SHORT).show();
-                }
-                dialog[0].dismiss();
-            });
-
-            LinearLayout.LayoutParams applyParams = new LinearLayout.LayoutParams(
-                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT
-            );
-            applyParams.setMargins(dp(8), 0, 0, 0);
-            applyBtn.setLayoutParams(applyParams);
-            buttons.addView(applyBtn);
-
-            layout.addView(buttons);
-
-            dialog[0] = customDialog(context, "Crop Image", layout);
-            dialog[0].show();
-        } catch (Throwable t) {
-            logger.error("Failed to show crop dialog", t);
-        }
-    }
-
-    private EditText dialogInput(Context context, String hint) {
+    EditText dialogInput(Context context, String hint) {
         EditText input = new EditText(context);
         input.setHint(hint);
         input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES);
@@ -2597,13 +1327,13 @@ public class PhotoEditorPlugin extends Plugin {
         }
     }
 
-    private void applyBrush(PhotoEditor editor) {
+    void applyBrush(PhotoEditor editor) {
         editor.setShape(new ShapeBuilder()
                 .withShapeColor(brushColor)
                 .withShapeSize(brushSize));
     }
 
-    private void loadImage(Uri uri, PhotoEditorView editorView, View editorHolder, ProgressBar progressBar) {
+    void loadImage(Uri uri, PhotoEditorView editorView, View editorHolder, ProgressBar progressBar) {
         Utils.threadPool.execute(() -> {
             try {
                 Bitmap bitmap = decodeBitmap(uri);
@@ -2640,7 +1370,7 @@ public class PhotoEditorPlugin extends Plugin {
         }
     }
 
-        private void addBitmapOverlay(PhotoEditorView editorView, Bitmap bitmap) {
+        void addBitmapOverlay(PhotoEditorView editorView, Bitmap bitmap) {
         android.widget.ImageView imageView = new android.widget.ImageView(editorView.getContext());
         imageView.setTag(OVERLAY_IMAGE);
         imageView.setImageBitmap(bitmap);
@@ -2679,7 +1409,7 @@ public class PhotoEditorPlugin extends Plugin {
         addManualOverlay(editorView, imageView);
     }
 
-    private void fillEditorBaseLayers(PhotoEditorView editorView) {
+    void fillEditorBaseLayers(PhotoEditorView editorView) {
         for (int i = 0; i < editorView.getChildCount(); i++) {
             View child = editorView.getChildAt(i);
             String className = child.getClass().getName();
@@ -2696,7 +1426,7 @@ public class PhotoEditorPlugin extends Plugin {
         }
     }
 
-    private void addTextOverlay(PhotoEditorView editorView, String text, int color, android.graphics.Typeface typeface, float textSize, boolean isUnderlined) {
+    void addTextOverlay(PhotoEditorView editorView, String text, int color, android.graphics.Typeface typeface, float textSize, boolean isUnderlined) {
         TextView textView = new TextView(editorView.getContext());
         textView.setTag(OVERLAY_TEXT);
         textView.setText(text);
@@ -2710,114 +1440,6 @@ public class PhotoEditorPlugin extends Plugin {
         textView.setShadowLayer(dp(2), dp(1), dp(1), 0xcc000000);
         textView.setPadding(dp(8), dp(4), dp(8), dp(4));
         addManualOverlay(editorView, textView);
-    }
-
-    private void showOverlayOptionsDialog(Context context, View viewToRemove, android.view.ViewGroup parent) {
-        android.app.Dialog dialog = new android.app.Dialog(context);
-        dialog.requestWindowFeature(android.view.Window.FEATURE_NO_TITLE);
-
-        android.widget.LinearLayout layout = new android.widget.LinearLayout(context);
-        layout.setOrientation(android.widget.LinearLayout.VERTICAL);
-        layout.setPadding(dp(24), dp(24), dp(24), dp(24));
-
-        android.graphics.drawable.GradientDrawable bg = new android.graphics.drawable.GradientDrawable();
-        bg.setColor(0xff313338);
-        bg.setCornerRadius(dp(16));
-        layout.setBackground(bg);
-
-        android.widget.TextView title = new android.widget.TextView(context);
-        title.setText("Overlay Options");
-        title.setTextColor(android.graphics.Color.WHITE);
-        title.setTextSize(20f);
-        title.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
-        title.setPadding(0, 0, 0, dp(12));
-
-        android.widget.TextView message = new android.widget.TextView(context);
-        message.setText("What would you like to do with this item?");
-        message.setTextColor(android.graphics.Color.parseColor("#dbdee1"));
-        message.setTextSize(16f);
-        message.setPadding(0, 0, 0, dp(24));
-
-        android.widget.LinearLayout buttons = new android.widget.LinearLayout(context);
-        buttons.setOrientation(android.widget.LinearLayout.HORIZONTAL);
-        buttons.setGravity(android.view.Gravity.END);
-        buttons.setPadding(0, dp(8), 0, 0);
-
-        android.widget.TextView cancel = new android.widget.TextView(context);
-        cancel.setText("Cancel");
-        cancel.setTextColor(android.graphics.Color.WHITE);
-        cancel.setTextSize(14f);
-        cancel.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
-        cancel.setPadding(dp(20), dp(10), dp(20), dp(10));
-        cancel.setOnClickListener(v -> dialog.dismiss());
-        buttons.addView(cancel);
-
-        if (viewToRemove instanceof android.widget.ImageView) {
-            android.widget.ImageView iv = (android.widget.ImageView) viewToRemove;
-            if (iv.getDrawable() instanceof android.graphics.drawable.BitmapDrawable) {
-                android.widget.TextView crop = new android.widget.TextView(context);
-                crop.setText("Crop");
-                crop.setTextColor(android.graphics.Color.WHITE);
-                crop.setTextSize(14f);
-                crop.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
-                crop.setPadding(dp(24), dp(10), dp(24), dp(10));
-
-                android.graphics.drawable.GradientDrawable cropBg = new android.graphics.drawable.GradientDrawable();
-                cropBg.setColor(0xff5865f2);
-                cropBg.setCornerRadius(dp(6));
-                crop.setBackground(cropBg);
-
-                android.widget.LinearLayout.LayoutParams cropParams = new android.widget.LinearLayout.LayoutParams(
-                        ViewGroup.LayoutParams.WRAP_CONTENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT
-                );
-                cropParams.setMargins(dp(8), 0, dp(8), 0);
-                crop.setLayoutParams(cropParams);
-
-                crop.setOnClickListener(v -> {
-                    dialog.dismiss();
-                    showCropDialog(context, iv, (PhotoEditorView) parent);
-                });
-                buttons.addView(crop);
-            }
-        }
-
-        android.widget.TextView delete = new android.widget.TextView(context);
-        delete.setText("Delete");
-        delete.setTextColor(android.graphics.Color.WHITE);
-        delete.setTextSize(14f);
-        delete.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
-        delete.setPadding(dp(24), dp(10), dp(24), dp(10));
-
-        android.graphics.drawable.GradientDrawable deleteBg = new android.graphics.drawable.GradientDrawable();
-        deleteBg.setColor(0xffda373c);
-        deleteBg.setCornerRadius(dp(6));
-        delete.setBackground(deleteBg);
-
-        android.widget.LinearLayout.LayoutParams delParams = new android.widget.LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        );
-        delParams.setMargins(dp(8), 0, 0, 0);
-        delete.setLayoutParams(delParams);
-
-        delete.setOnClickListener(v -> {
-            parent.removeView(viewToRemove);
-            dialog.dismiss();
-        });
-        buttons.addView(delete);
-
-        layout.addView(title);
-        layout.addView(message);
-        layout.addView(buttons);
-
-        dialog.setContentView(layout);
-        android.view.Window win = dialog.getWindow();
-        if (win != null) {
-            win.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT));
-            win.setLayout((int) (android.content.res.Resources.getSystem().getDisplayMetrics().widthPixels * 0.9f), android.view.ViewGroup.LayoutParams.WRAP_CONTENT);
-        }
-        dialog.show();
     }
 
     private void addManualOverlay(PhotoEditorView editorView, View overlay) {
@@ -2840,7 +1462,7 @@ public class PhotoEditorPlugin extends Plugin {
 
             overlay.setVisibility(View.VISIBLE);
             overlay.setAlpha(1f);
-            overlay.setOnTouchListener(new OverlayTouchListener(editorView));
+            overlay.setOnTouchListener(new PhotoEditorOverlayTouchListener(this, editorView));
             overlay.bringToFront();
             overlay.requestLayout();
             Toast.makeText(editorView.getContext(), "Added to image. Drag to move, pinch to scale.", Toast.LENGTH_SHORT).show();
@@ -2850,263 +1472,6 @@ public class PhotoEditorPlugin extends Plugin {
             add.run();
         else
             editorView.post(add);
-    }
-
-    private void showEditTextOverlayDialog(Context context, TextView target) {
-        Dialog dialog = new Dialog(context);
-        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
-
-        LinearLayout layout = createBottomSheetContainer(context, "Edit Text");
-        EditText input = dialogInput(context, "Enter your text...");
-        input.setText(target.getText());
-        input.setSelectAllOnFocus(false);
-        input.setSelection(input.getText().length());
-
-        android.graphics.drawable.GradientDrawable inputBg = new android.graphics.drawable.GradientDrawable();
-        inputBg.setColor(0xff1e1f22);
-        inputBg.setCornerRadius(dp(8));
-        inputBg.setStroke(dp(1), Color.parseColor("#3f4147"));
-        input.setBackground(inputBg);
-        input.setTextColor(Color.WHITE);
-        input.setHintTextColor(Color.parseColor("#80848e"));
-        input.setTextSize(16f);
-        input.setMinLines(2);
-        input.setGravity(Gravity.TOP | Gravity.START);
-        input.setPadding(dp(12), dp(12), dp(12), dp(12));
-        LinearLayout.LayoutParams inputParams = new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        );
-        inputParams.setMargins(0, 0, 0, dp(16));
-        layout.addView(input, inputParams);
-
-        final int[] chosenColor = {target.getCurrentTextColor()};
-        TextView colorLabel = new TextView(context);
-        colorLabel.setText("Color");
-        colorLabel.setTextColor(Color.parseColor("#b5bac1"));
-        colorLabel.setTextSize(12f);
-        colorLabel.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
-        colorLabel.setPadding(0, 0, 0, dp(8));
-        layout.addView(colorLabel);
-
-        LinearLayout colorRow = new LinearLayout(context);
-        colorRow.setOrientation(LinearLayout.HORIZONTAL);
-        colorRow.setGravity(Gravity.CENTER_VERTICAL);
-        List<View> swatches = new ArrayList<>();
-        for (int color : COLORS) {
-            View swatch = colorSwatch(context, color, view -> {
-                chosenColor[0] = color;
-                selectColorOnly(swatches, color);
-            });
-            swatch.setTag(color);
-            swatches.add(swatch);
-            colorRow.addView(swatch);
-        }
-        selectColorOnly(swatches, chosenColor[0]);
-        LinearLayout.LayoutParams colorParams = new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        );
-        colorParams.setMargins(0, 0, 0, dp(18));
-        layout.addView(colorRow, colorParams);
-
-        LinearLayout buttons = new LinearLayout(context);
-        buttons.setOrientation(LinearLayout.HORIZONTAL);
-        buttons.setGravity(Gravity.RIGHT);
-
-        TextView deleteBtn = dialogButton(context, "Delete", Color.parseColor("#f23f42"), false);
-        deleteBtn.setOnClickListener(v -> {
-            ViewGroup parent = (ViewGroup) target.getParent();
-            if (parent != null)
-                parent.removeView(target);
-            dialog.dismiss();
-        });
-        buttons.addView(deleteBtn);
-
-        TextView cancelBtn = dialogButton(context, "Cancel", Color.parseColor("#dbdee1"), false);
-        cancelBtn.setOnClickListener(v -> dialog.dismiss());
-        buttons.addView(cancelBtn);
-
-        TextView saveBtn = dialogButton(context, "Save", Color.WHITE, true);
-        saveBtn.setOnClickListener(v -> {
-            String text = input.getText().toString().trim();
-            if (!text.isEmpty()) {
-                target.setText(text);
-                target.setTextColor(chosenColor[0]);
-                target.requestLayout();
-            }
-            dialog.dismiss();
-        });
-        LinearLayout.LayoutParams saveParams = new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        );
-        saveParams.setMargins(dp(8), 0, 0, 0);
-        saveBtn.setLayoutParams(saveParams);
-        buttons.addView(saveBtn);
-
-        layout.addView(buttons);
-        showKeyboardDialog(dialog, layout, input);
-    }
-
-    private TextView dialogButton(Context context, String text, int color, boolean primary) {
-        TextView button = new TextView(context);
-        button.setText(text);
-        button.setTextColor(color);
-        button.setTextSize(14f);
-        button.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
-        button.setGravity(Gravity.CENTER);
-        button.setPadding(dp(14), dp(10), dp(14), dp(10));
-        
-        android.graphics.drawable.GradientDrawable bg = new android.graphics.drawable.GradientDrawable();
-        if (primary) {
-            bg.setColor(0xff5865f2);
-        } else {
-            bg.setColor(Color.TRANSPARENT);
-        }
-        bg.setCornerRadius(dp(8));
-        
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            android.content.res.ColorStateList rippleColor = android.content.res.ColorStateList.valueOf(0x40ffffff);
-            android.graphics.drawable.RippleDrawable ripple = new android.graphics.drawable.RippleDrawable(rippleColor, bg, null);
-            button.setBackground(ripple);
-        } else {
-            button.setBackground(bg);
-        }
-        
-        addPressAnimation(button);
-        return button;
-    }
-
-    public static class ImagePickerFragment extends androidx.fragment.app.Fragment {
-        private OnImagePickedListener listener;
-
-        public void setListener(OnImagePickedListener listener) {
-            this.listener = listener;
-        }
-
-        @Override
-        public void onCreate(android.os.Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
-            android.content.Intent intent = new android.content.Intent(android.content.Intent.ACTION_GET_CONTENT);
-            intent.setType("image/*");
-            startActivityForResult(intent, 54321);
-        }
-
-        @Override
-        public void onActivityResult(int requestCode, int resultCode, android.content.Intent data) {
-            super.onActivityResult(requestCode, resultCode, data);
-            if (requestCode == 54321) {
-                if (resultCode == android.app.Activity.RESULT_OK && data != null && data.getData() != null) {
-                    if (listener != null) listener.onImagePicked(data.getData());
-                } else {
-                    if (listener != null) listener.onImagePicked(null);
-                }
-                listener = null;
-                getParentFragmentManager().beginTransaction().remove(this).commitAllowingStateLoss();
-            }
-        }
-
-        public interface OnImagePickedListener {
-            void onImagePicked(android.net.Uri uri);
-        }
-    }
-
-    private class OverlayTouchListener implements View.OnTouchListener {
-        private final View parent;
-        private float downRawX;
-        private float downRawY;
-        private float startX;
-        private float startY;
-        private float startDistance;
-        private float startScale;
-        private long downTime;
-        private boolean moved;
-        private int mode;
-        private Runnable longClickRunnable;
-
-        private OverlayTouchListener(View parent) {
-            this.parent = parent;
-        }
-
-        @Override
-        public boolean onTouch(View view, MotionEvent event) {
-            switch (event.getActionMasked()) {
-                case MotionEvent.ACTION_DOWN:
-                    view.bringToFront();
-                    downRawX = event.getRawX();
-                    downRawY = event.getRawY();
-                    startX = view.getX();
-                    startY = view.getY();
-                    downTime = System.currentTimeMillis();
-                    moved = false;
-                    mode = 0;
-
-                    if (longClickRunnable != null) view.removeCallbacks(longClickRunnable);
-                    longClickRunnable = () -> {
-                        if (!moved) {
-                            showOverlayOptionsDialog(view.getContext(), view, (android.view.ViewGroup) parent);
-                        }
-                    };
-                    view.postDelayed(longClickRunnable, 500);
-                    return true;
-                case MotionEvent.ACTION_POINTER_DOWN:
-                    if (longClickRunnable != null) view.removeCallbacks(longClickRunnable);
-                    if (event.getPointerCount() == 2) {
-                        startDistance = pointerDistance(event);
-                        startScale = view.getScaleX();
-                        mode = 1;
-                    }
-                    return true;
-                case MotionEvent.ACTION_MOVE:
-                    if (mode == 1 && event.getPointerCount() >= 2) {
-                        float newDist = pointerDistance(event);
-                        if (newDist > 10f) {
-                            float scale = (newDist / startDistance) * startScale;
-                            view.setScaleX(Math.max(0.1f, scale));
-                            view.setScaleY(Math.max(0.1f, scale));
-                        }
-                    } else if (mode == 0) {
-                        float deltaX = event.getRawX() - downRawX;
-                        float deltaY = event.getRawY() - downRawY;
-                        if (Math.abs(deltaX) > dp(4) || Math.abs(deltaY) > dp(4)) {
-                            moved = true;
-                            if (longClickRunnable != null) view.removeCallbacks(longClickRunnable);
-                        }
-                        float nextX = startX + deltaX;
-                        float nextY = startY + deltaY;
-                        float maxX = Math.max(0, parent.getWidth() - view.getWidth());
-                        float maxY = Math.max(0, parent.getHeight() - view.getHeight());
-                        view.setX(Math.max(0, Math.min(maxX, nextX)));
-                        view.setY(Math.max(0, Math.min(maxY, nextY)));
-                    }
-                    return true;
-                case MotionEvent.ACTION_POINTER_UP:
-                    if (event.getPointerCount() <= 2)
-                        mode = 1;
-                    return true;
-                case MotionEvent.ACTION_UP:
-                    if (longClickRunnable != null) view.removeCallbacks(longClickRunnable);
-                    if (!moved && System.currentTimeMillis() - downTime < 350 && OVERLAY_TEXT.equals(view.getTag()) && view instanceof android.widget.TextView)
-                        showEditTextOverlayDialog(view.getContext(), (android.widget.TextView) view);
-                    mode = 0;
-                    return true;
-                case MotionEvent.ACTION_CANCEL:
-                    if (longClickRunnable != null) view.removeCallbacks(longClickRunnable);
-                    mode = 0;
-                    return true;
-                default:
-                    return true;
-            }
-        }
-
-        private float pointerDistance(MotionEvent event) {
-            if (event.getPointerCount() < 2)
-                return 0f;
-            float dx = event.getX(0) - event.getX(1);
-            float dy = event.getY(0) - event.getY(1);
-            return (float) Math.sqrt(dx * dx + dy * dy);
-        }
     }
 
     private void clearAllEditorOverlays(PhotoEditor editor, PhotoEditorView editorView) {
@@ -3125,290 +1490,7 @@ public class PhotoEditorPlugin extends Plugin {
         }
     }
 
-    private void saveImage(Context context, PhotoEditor editor, PhotoEditorView editorView, Attachment<?>[] currentAttachment, EditRequest editRequest, Dialog dialog, PhotoFilter[] sessionFilter, boolean[] isCustomFilter, float[] customFilterValues) {
-        try {
-            editor.clearHelperBox();
-
-            // Obtain source bitmap
-            Bitmap srcBitmap = null;
-            android.graphics.drawable.Drawable srcDrawable = editorView.getSource().getDrawable();
-            if (srcDrawable instanceof android.graphics.drawable.BitmapDrawable) {
-                srcBitmap = ((android.graphics.drawable.BitmapDrawable) srcDrawable).getBitmap();
-            }
-            if (srcBitmap == null || srcBitmap.getWidth() <= 0 || srcBitmap.getHeight() <= 0) {
-                throw new IllegalStateException("Invalid source bitmap");
-            }
-
-            PhotoFilter activeFilter = (sessionFilter != null && sessionFilter[0] != null)
-                    ? sessionFilter[0] : PhotoFilter.NONE;
-            boolean isGlOnly = isGlOnlyFilter(activeFilter);
-
-            if (isGlOnly && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-                android.view.SurfaceView glView = null;
-                for (int i = 0; i < editorView.getChildCount(); i++) {
-                    View child = editorView.getChildAt(i);
-                    if (child instanceof android.view.SurfaceView) {
-                        glView = (android.view.SurfaceView) child;
-                        break;
-                    }
-                }
-                if (glView != null && glView.getWidth() > 0 && glView.getHeight() > 0) {
-                    Bitmap glBitmap = Bitmap.createBitmap(glView.getWidth(), glView.getHeight(), Bitmap.Config.ARGB_8888);
-                    android.view.PixelCopy.request(glView, glBitmap, copyResult -> {
-                        if (copyResult == android.view.PixelCopy.SUCCESS) {
-                            Canvas canvas = new Canvas(glBitmap);
-                            // Draw overlays on top, unscaled (since glView and children share the same layout space)
-                            for (int i = 0; i < editorView.getChildCount(); i++) {
-                                View child = editorView.getChildAt(i);
-                                if (child == editorView.getSource() || child instanceof android.view.SurfaceView) continue;
-                                canvas.save();
-                                canvas.translate(child.getX(), child.getY());
-                                float pivX = child.getPivotX();
-                                float pivY = child.getPivotY();
-                                canvas.scale(child.getScaleX(), child.getScaleY(), pivX, pivY);
-                                if (child.getRotation() != 0f) canvas.rotate(child.getRotation(), pivX, pivY);
-                                child.draw(canvas);
-                                canvas.restore();
-                            }
-                            writeBitmapToFile(context, currentAttachment, editRequest, dialog, activeFilter, glBitmap);
-                        } else {
-                            Toast.makeText(context, "Failed to capture GL filter: " + copyResult, Toast.LENGTH_SHORT).show();
-                        }
-                    }, new android.os.Handler(android.os.Looper.getMainLooper()));
-                    return; // Async save handling
-                }
-            }
-
-            // Normal save for NONE or ColorMatrix filters (Full-res)
-            int outW = srcBitmap.getWidth();
-            int outH = srcBitmap.getHeight();
-            Bitmap saveBitmap = Bitmap.createBitmap(outW, outH, Bitmap.Config.ARGB_8888);
-            Canvas canvas = new Canvas(saveBitmap);
-
-            Paint srcPaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.FILTER_BITMAP_FLAG);
-            float[] matrix = isCustomFilter != null && isCustomFilter[0] ? buildCustomMatrix(customFilterValues) : getColorMatrixForFilter(activeFilter);
-            
-            boolean applyToEverything = settings.getInt("filter_apply_mode", 0) == 1;
-            
-            if (matrix != null && !applyToEverything) {
-                srcPaint.setColorFilter(new android.graphics.ColorMatrixColorFilter(matrix));
-            }
-            canvas.drawBitmap(srcBitmap, 0, 0, srcPaint);
-
-            float scaleX = (float) outW / Math.max(1, editorView.getWidth());
-            float scaleY = (float) outH / Math.max(1, editorView.getHeight());
-            canvas.save();
-            canvas.scale(scaleX, scaleY);
-            for (int i = 0; i < editorView.getChildCount(); i++) {
-                View child = editorView.getChildAt(i);
-                if (child == editorView.getSource()) continue;
-                if (child.getClass().getName().contains("ImageFilterView")) continue;
-                canvas.save();
-                canvas.translate(child.getX(), child.getY());
-                float pivX = child.getPivotX();
-                float pivY = child.getPivotY();
-                canvas.scale(child.getScaleX(), child.getScaleY(), pivX, pivY);
-                if (child.getRotation() != 0f) canvas.rotate(child.getRotation(), pivX, pivY);
-                child.draw(canvas);
-                canvas.restore();
-            }
-            canvas.restore();
-
-            if (matrix != null && applyToEverything) {
-                Bitmap finalSaveBitmap = Bitmap.createBitmap(outW, outH, Bitmap.Config.ARGB_8888);
-                Canvas finalCanvas = new Canvas(finalSaveBitmap);
-                Paint finalPaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.FILTER_BITMAP_FLAG);
-                finalPaint.setColorFilter(new android.graphics.ColorMatrixColorFilter(matrix));
-                finalCanvas.drawBitmap(saveBitmap, 0, 0, finalPaint);
-                saveBitmap.recycle();
-                saveBitmap = finalSaveBitmap;
-            }
-
-            writeBitmapToFile(context, currentAttachment, editRequest, dialog, activeFilter, saveBitmap);
-        } catch (Throwable throwable) {
-            logger.error(throwable);
-            Toast.makeText(context, "Failed to render image: " + throwable.getMessage(), Toast.LENGTH_LONG).show();
-        }
-    }
-
-    private void writeBitmapToFile(Context context, Attachment<?>[] currentAttachment, EditRequest editRequest, Dialog dialog, PhotoFilter activeFilter, Bitmap finalBitmap) {
-        Utils.threadPool.execute(() -> {
-            try {
-                Attachment<?> original = currentAttachment[0];
-                File output = nextOutputFile(context, original.getDisplayName());
-                try (FileOutputStream stream = new FileOutputStream(output)) {
-                    finalBitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
-                }
-
-                Attachment<?> edited = new Attachment<>(
-                        output.getAbsolutePath().hashCode(),
-                        Uri.fromFile(output),
-                        output.getName(),
-                        null,
-                        original.getSpoiler()
-                );
-
-                String filterDesc = (activeFilter != null && activeFilter != PhotoFilter.NONE)
-                        ? " (" + humanize(activeFilter.name()) + " filter)" : "";
-                Utils.mainThread.post(() -> {
-                    editRequest.onEdited(original, edited);
-                    Toast.makeText(context, "Saved" + filterDesc, Toast.LENGTH_SHORT).show();
-                    dialog.dismiss();
-                });
-            } catch (Throwable throwable) {
-                logger.error(throwable);
-                Utils.mainThread.post(() -> Toast.makeText(context, "Failed to save image", Toast.LENGTH_SHORT).show());
-            }
-        });
-    }
-
-    /**
-     * Maps a PhotoFilter to a 4×5 ColorMatrix array for software rendering.
-     * Returns null for NONE or filters without a meaningful color matrix equivalent.
-     */
-    private float[] getColorMatrixForFilter(PhotoFilter filter) {
-        if (filter == null || filter == PhotoFilter.NONE) return null;
-        switch (filter) {
-            case GRAY_SCALE:
-                return new float[]{
-                    0.21f, 0.72f, 0.07f, 0, 0,
-                    0.21f, 0.72f, 0.07f, 0, 0,
-                    0.21f, 0.72f, 0.07f, 0, 0,
-                    0,     0,     0,     1, 0
-                };
-            case SEPIA:
-                return new float[]{
-                    0.393f, 0.769f, 0.189f, 0, 0,
-                    0.349f, 0.686f, 0.168f, 0, 0,
-                    0.272f, 0.534f, 0.131f, 0, 0,
-                    0,      0,      0,      1, 0
-                };
-            case NEGATIVE:
-                return new float[]{
-                    -1,  0,  0, 0, 255,
-                     0, -1,  0, 0, 255,
-                     0,  0, -1, 0, 255,
-                     0,  0,  0, 1,   0
-                };
-            case BRIGHTNESS:
-                return new float[]{
-                    1, 0, 0, 0, 55,
-                    0, 1, 0, 0, 55,
-                    0, 0, 1, 0, 55,
-                    0, 0, 0, 1,  0
-                };
-            case CONTRAST: {
-                float s = 1.5f, t = (-.5f * s + .5f) * 255f;
-                return new float[]{
-                    s, 0, 0, 0, t,
-                    0, s, 0, 0, t,
-                    0, 0, s, 0, t,
-                    0, 0, 0, 1, 0
-                };
-            }
-            case SATURATE:
-                return new float[]{
-                     1.8f, -0.4f, -0.4f, 0, 0,
-                    -0.4f,  1.8f, -0.4f, 0, 0,
-                    -0.4f, -0.4f,  1.8f, 0, 0,
-                     0,     0,     0,    1, 0
-                };
-            case TEMPERATURE:
-                // Warm: boost red, reduce blue
-                return new float[]{
-                    1.15f, 0,    0,     0,  10,
-                    0,     1.0f, 0,     0,   0,
-                    0,     0,    0.75f, 0, -15,
-                    0,     0,    0,     1,   0
-                };
-            case TINT:
-                // Subtle cool tint
-                return new float[]{
-                    0.9f, 0,    0,    0, 0,
-                    0,    1.0f, 0,    0, 5,
-                    0,    0,    1.1f, 0, 10,
-                    0,    0,    0,    1, 0
-                };
-            case DUE_TONE:
-                // Duotone: map to teal-purple
-                return new float[]{
-                    0.3f, 0.5f, 0.2f, 0, 20,
-                    0.1f, 0.4f, 0.5f, 0, 30,
-                    0.4f, 0.2f, 0.4f, 0, 40,
-                    0,    0,    0,    1,  0
-                };
-            case LOMISH:
-                // Lo-fi: faded, slightly warm
-                return new float[]{
-                    0.9f, 0.1f, 0,    0, 20,
-                    0,    0.85f,0.1f, 0, 15,
-                    0.1f, 0,    0.8f, 0, 10,
-                    0,    0,    0,    1,  0
-                };
-            case POSTERIZE: {
-                // Crude posterize via high contrast + slight desaturate
-                float ps = 2.5f, pt = (-.5f * ps + .5f) * 255f;
-                return new float[]{
-                    ps, 0,  0,  0, pt,
-                    0,  ps, 0,  0, pt,
-                    0,  0,  ps, 0, pt,
-                    0,  0,  0,  1,  0
-                };
-            }
-            case GRAIN:
-                // Grain is random, can't do with ColorMatrix — return null
-                return null;
-            case FILL_LIGHT:
-                return new float[]{
-                    1, 0, 0, 0, 30,
-                    0, 1, 0, 0, 30,
-                    0, 0, 1, 0, 30,
-                    0, 0, 0, 1,  0
-                };
-            case FISH_EYE:
-                // Geometric distortion — not possible with ColorMatrix
-                return null;
-            case VIGNETTE:
-                // Radial effect — not possible with ColorMatrix
-                return null;
-            case DOCUMENTARY:
-                // Desaturated + high contrast
-                return new float[]{
-                    0.33f, 0.50f, 0.17f, 0,  0,
-                    0.33f, 0.50f, 0.17f, 0,  0,
-                    0.33f, 0.50f, 0.17f, 0,  0,
-                    0,     0,     0,     1, -5
-                };
-            case SHARPEN:
-                return null; // Convolution kernel — not possible with ColorMatrix
-            case AUTO_FIX:
-                return new float[]{
-                    1.1f, 0,    0,    0, 5,
-                    0,    1.1f, 0,    0, 5,
-                    0,    0,    1.1f, 0, 5,
-                    0,    0,    0,    1, 0
-                };
-            default:
-                return null;
-        }
-    }
-
-    private File nextOutputFile(Context context, String displayName) {
-        File dir = new File(context.getExternalFilesDir(Environment.DIRECTORY_PICTURES), "PhotoEditor");
-        if (!dir.exists() && !dir.mkdirs())
-            dir = context.getCacheDir();
-        return new File(dir, editedFileName(displayName));
-    }
-
-    private String editedFileName(String displayName) {
-        String baseName = displayName == null ? "image" : displayName.replaceAll("(?i)\\.[a-z0-9]{1,5}$", "");
-        baseName = baseName.replaceAll("[^A-Za-z0-9._-]", "_");
-        if (baseName.isEmpty())
-            baseName = "image";
-        return baseName + "-edited-" + System.currentTimeMillis() + ".png";
-    }
-
-    private void replaceAttachment(SelectionAggregator<?> aggregator, Attachment<?> original, Attachment<?> edited) {
+    void replaceAttachment(SelectionAggregator<?> aggregator, Attachment<?> original, Attachment<?> edited) {
         try {
             Method remove = SelectionAggregator.class.getDeclaredMethod("removeItem", Attachment.class);
             remove.setAccessible(true);
@@ -3442,13 +1524,10 @@ public class PhotoEditorPlugin extends Plugin {
                 || lower.endsWith(".heif");
     }
 
-    @SuppressLint("DefaultLocale")
-    private String humanize(String name) {
-        String lower = name.toLowerCase(Locale.ROOT).replace('_', ' ');
-        return lower.substring(0, 1).toUpperCase(Locale.ROOT) + lower.substring(1);
-    }
+    void logError(Throwable throwable) { logger.error(throwable); }
+    void logError(String message, Throwable throwable) { logger.error(message, throwable); }
 
-    private int dp(int value) {
+    int dp(int value) {
         return DimenUtils.dpToPx(value);
     }
 
@@ -3460,7 +1539,7 @@ public class PhotoEditorPlugin extends Plugin {
         }
     }
 
-    private void addRippleBorderless(View view) {
+    void addRippleBorderless(View view) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             android.util.TypedValue outValue = new android.util.TypedValue();
             view.getContext().getTheme().resolveAttribute(android.R.attr.selectableItemBackgroundBorderless, outValue, true);
@@ -3469,7 +1548,7 @@ public class PhotoEditorPlugin extends Plugin {
     }
 
     @SuppressLint("ClickableViewAccessibility")
-    private void addPressAnimation(View view) {
+    void addPressAnimation(View view) {
         view.setOnTouchListener((v, event) -> {
             switch (event.getAction()) {
                 case MotionEvent.ACTION_DOWN:
@@ -3484,174 +1563,7 @@ public class PhotoEditorPlugin extends Plugin {
         });
     }
 
-    private float[] buildCustomMatrix(float[] values) {
-        float brightness = values[0];
-        float contrast = values[1];
-        float saturation = values[2];
-        float hue = values[3];
-        float temp = values[4];
-        float tint = values[5];
-
-        android.graphics.ColorMatrix cm = new android.graphics.ColorMatrix();
-        
-        // Brightness & Contrast
-        float t = (1f - contrast) * 128f + brightness;
-        android.graphics.ColorMatrix cmContrast = new android.graphics.ColorMatrix(new float[]{
-            contrast, 0, 0, 0, t,
-            0, contrast, 0, 0, t,
-            0, 0, contrast, 0, t,
-            0, 0, 0, 1, 0
-        });
-        cm.postConcat(cmContrast);
-
-        // Saturation
-        android.graphics.ColorMatrix cmSat = new android.graphics.ColorMatrix();
-        cmSat.setSaturation(saturation);
-        cm.postConcat(cmSat);
-
-        // Hue
-        if (hue != 0f) {
-            float cos = (float) Math.cos(hue * Math.PI / 180f);
-            float sin = (float) Math.sin(hue * Math.PI / 180f);
-            float lumR = 0.213f, lumG = 0.715f, lumB = 0.072f;
-            android.graphics.ColorMatrix cmHue = new android.graphics.ColorMatrix(new float[]{
-                lumR + cos * (1 - lumR) + sin * (-lumR), lumG + cos * (-lumG) + sin * (-lumG), lumB + cos * (-lumB) + sin * (1 - lumB), 0, 0,
-                lumR + cos * (-lumR) + sin * (0.143f), lumG + cos * (1 - lumG) + sin * (0.140f), lumB + cos * (-lumB) + sin * (-0.283f), 0, 0,
-                lumR + cos * (-lumR) + sin * (-(1 - lumR)), lumG + cos * (-lumG) + sin * (lumG), lumB + cos * (1 - lumB) + sin * (lumB), 0, 0,
-                0, 0, 0, 1, 0
-            });
-            cm.postConcat(cmHue);
-        }
-
-        // Temperature (Warm/Cool) & Tint (Green/Magenta)
-        if (temp != 0f || tint != 0f) {
-            float rTemp = temp > 0 ? temp * 0.1f : 0;
-            float bTemp = temp < 0 ? -temp * 0.1f : 0;
-            float gTint = tint > 0 ? tint * 0.1f : 0;
-            float rTint = tint < 0 ? -tint * 0.1f : 0;
-            float bTint = tint < 0 ? -tint * 0.1f : 0;
-            
-            android.graphics.ColorMatrix cmTempTint = new android.graphics.ColorMatrix(new float[]{
-                1f + rTemp + rTint, 0, 0, 0, 0,
-                0, 1f + gTint, 0, 0, 0,
-                0, 0, 1f + bTemp + bTint, 0, 0,
-                0, 0, 0, 1, 0
-            });
-            cm.postConcat(cmTempTint);
-        }
-
-        return cm.getArray();
-    }
-
-    private void showCustomFilterDialog(Context context, PhotoEditorView editorView, float[] customFilterValues) {
-        Dialog dialog = new Dialog(context);
-        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
-
-        LinearLayout layout = createBottomSheetContainer(context);
-        android.widget.ScrollView scrollContent = new android.widget.ScrollView(context);
-        LinearLayout content = new LinearLayout(context);
-        content.setOrientation(LinearLayout.VERTICAL);
-
-        Runnable updateFilter = () -> {
-            for (int i=0; i<editorView.getChildCount(); i++) {
-                android.view.View child = editorView.getChildAt(i);
-                if (child.getClass().getName().contains("ImageFilterView")) {
-                    child.setVisibility(android.view.View.GONE);
-                }
-            }
-            float[] matrix = buildCustomMatrix(customFilterValues);
-            boolean applyToEverything = settings.getInt("filter_apply_mode", 0) == 1;
-            if (applyToEverything) {
-                Paint p = new Paint();
-                p.setColorFilter(new android.graphics.ColorMatrixColorFilter(matrix));
-                editorView.setLayerType(android.view.View.LAYER_TYPE_HARDWARE, p);
-                editorView.getSource().clearColorFilter();
-            } else {
-                editorView.setLayerType(android.view.View.LAYER_TYPE_NONE, null);
-                editorView.getSource().setColorFilter(new android.graphics.ColorMatrixColorFilter(matrix));
-            }
-        };
-
-        String[] labels = {"Brightness", "Contrast", "Saturation", "Hue", "Temperature", "Tint"};
-        float[] mins = {-100f, 0f, 0f, -180f, -50f, -50f};
-        float[] maxs = {100f, 2f, 2f, 180f, 50f, 50f};
-        float[] defaults = {0f, 1f, 1f, 0f, 0f, 0f};
-
-        for (int i = 0; i < 6; i++) {
-            final int index = i;
-            LinearLayout row = new LinearLayout(context);
-            row.setOrientation(LinearLayout.VERTICAL);
-            row.setPadding(0, 0, 0, dp(16));
-
-            LinearLayout header = new LinearLayout(context);
-            header.setOrientation(LinearLayout.HORIZONTAL);
-            
-            TextView label = new TextView(context);
-            label.setText(labels[i]);
-            label.setTextColor(Color.WHITE);
-            label.setTextSize(14f);
-            
-            TextView valueText = new TextView(context);
-            valueText.setText(String.format(java.util.Locale.US, "%.2f", customFilterValues[i]));
-            valueText.setTextColor(Color.GRAY);
-            valueText.setTextSize(12f);
-            
-            LinearLayout.LayoutParams lblParams = new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
-            header.addView(label, lblParams);
-            header.addView(valueText);
-            
-            row.addView(header);
-
-            com.google.android.material.slider.Slider slider = PhotoEditorUi.createDiscordSlider(context, 0, 200, 0);
-            
-            float current = customFilterValues[i];
-            float range = maxs[i] - mins[i];
-            int progress = (int) (((current - mins[i]) / range) * 200f);
-            slider.setValue(progress);
-
-            slider.addOnChangeListener((view, value, fromUser) -> {
-                if (fromUser) {
-                    float val = mins[index] + (value / 200f) * range;
-                    customFilterValues[index] = val;
-                    valueText.setText(String.format(java.util.Locale.US, "%.2f", val));
-                    updateFilter.run();
-                }
-            });
-            row.addView(slider);
-            content.addView(row);
-        }
-        
-        TextView resetBtn = new TextView(context);
-        resetBtn.setText("Reset Custom Filter");
-        resetBtn.setTextColor(0xffda373c);
-        resetBtn.setTextSize(14f);
-        resetBtn.setGravity(Gravity.CENTER);
-        resetBtn.setPadding(dp(16), dp(16), dp(16), dp(16));
-        resetBtn.setOnClickListener(v -> {
-            System.arraycopy(defaults, 0, customFilterValues, 0, defaults.length);
-            updateFilter.run();
-            dialog.dismiss();
-            showCustomFilterDialog(context, editorView, customFilterValues); // Reopen to refresh sliders
-        });
-        content.addView(resetBtn);
-
-        scrollContent.addView(content);
-        layout.addView(scrollContent, new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                dp(300)
-        ));
-
-        dialog.setContentView(layout);
-        Window window = dialog.getWindow();
-        if (window != null) {
-            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
-            window.setGravity(Gravity.BOTTOM);
-            window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        }
-        dialog.show();
-    }
-
-    private interface EditRequest {
+    interface EditRequest {
         void onEdited(Attachment<?> oldAttachment, Attachment<?> newAttachment);
     }
 
@@ -3671,13 +1583,3 @@ public class PhotoEditorPlugin extends Plugin {
         }
     }
 }
-
-
-
-
-
-
-
-
-
-

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -116,12 +116,12 @@ public class PhotoEditorPlugin extends Plugin {
         ));
 
         FrameLayout subToolbarContainer = new FrameLayout(context);
-        subToolbarContainer.setVisibility(View.GONE);
+        subToolbarContainer.setVisibility(View.INVISIBLE);
         subToolbarContainer.setBackgroundColor(0xff2b2d31);
         
         rootContainer.addView(subToolbarContainer, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
+                dp(52)
         ));
         rootContainer.addView(mainScroll, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
@@ -380,7 +380,7 @@ public class PhotoEditorPlugin extends Plugin {
 
         View textMainBtn = iconButton(context, "Text", "ic_text_image_24dp", v -> {
             selectOnly(mainButtons, null);
-            subToolbarContainer.setVisibility(View.GONE);
+            subToolbarContainer.setVisibility(View.INVISIBLE);
             editor.setBrushDrawingMode(false);
             showTextDialog(context, editor, editorView);
         });
@@ -388,7 +388,7 @@ public class PhotoEditorPlugin extends Plugin {
 
         View emojiMainBtn = iconButton(context, "Emoji", "ic_emoji_24dp", v -> {
             selectOnly(mainButtons, null);
-            subToolbarContainer.setVisibility(View.GONE);
+            subToolbarContainer.setVisibility(View.INVISIBLE);
             editor.setBrushDrawingMode(false);
             showDiscordEmojiPicker(context, editor, editorView);
         });
@@ -396,7 +396,7 @@ public class PhotoEditorPlugin extends Plugin {
 
         View stickerMainBtn = iconButton(context, "Sticker", "ic_sticker_icon_24dp", v -> {
             selectOnly(mainButtons, null);
-            subToolbarContainer.setVisibility(View.GONE);
+            subToolbarContainer.setVisibility(View.INVISIBLE);
             editor.setBrushDrawingMode(false);
             showDiscordStickerPicker(context, editor, editorView);
         });
@@ -404,7 +404,7 @@ public class PhotoEditorPlugin extends Plugin {
 
         View imageMainBtn = iconButton(context, "Image", "ic_photo_grey_24dp", v -> {
             selectOnly(mainButtons, null);
-            subToolbarContainer.setVisibility(View.GONE);
+            subToolbarContainer.setVisibility(View.INVISIBLE);
             editor.setBrushDrawingMode(false);
             showImagePicker(context, editor, editorView);
         });
@@ -412,7 +412,7 @@ public class PhotoEditorPlugin extends Plugin {
 
         View cropMainBtn = iconButton(context, "Crop", "ucrop_ic_crop", v -> {
             selectOnly(mainButtons, null);
-            subToolbarContainer.setVisibility(View.GONE);
+            subToolbarContainer.setVisibility(View.INVISIBLE);
             editor.setBrushDrawingMode(false);
             showCropDialog(context, editorView.getSource(), editorView);
         });

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -1235,7 +1235,7 @@ public class PhotoEditorPlugin extends Plugin {
         
         android.widget.EditText hexInput = new android.widget.EditText(context);
         hexInput.setTextColor(Color.WHITE);
-        hexInput.setText(String.format("#%06X", (0xFFFFFF & initialColor)));
+        hexInput.setText(String.format("#%08X", initialColor));
         hexInput.setSingleLine(true);
         LinearLayout.LayoutParams hexParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         hexParams.setMargins(dp(16), 0, 0, 0);
@@ -1254,6 +1254,9 @@ public class PhotoEditorPlugin extends Plugin {
         
         TextView valLabel = new TextView(context); valLabel.setText("Lightness"); valLabel.setTextColor(Color.LTGRAY); valLabel.setPadding(0, dp(8), 0, 0); root.addView(valLabel);
         android.widget.SeekBar valSlider = new android.widget.SeekBar(context); valSlider.setMax(100); valSlider.setProgress((int) (hsv[2] * 100)); root.addView(valSlider);
+        
+        TextView alphaLabel = new TextView(context); alphaLabel.setText("Opacity"); alphaLabel.setTextColor(Color.LTGRAY); alphaLabel.setPadding(0, dp(8), 0, 0); root.addView(alphaLabel);
+        android.widget.SeekBar alphaSlider = new android.widget.SeekBar(context); alphaSlider.setMax(255); alphaSlider.setProgress(Color.alpha(initialColor)); root.addView(alphaSlider);
         
         // 4. Presets Horizontal Scroll
         android.widget.HorizontalScrollView presetScroll = new android.widget.HorizontalScrollView(context);
@@ -1274,6 +1277,7 @@ public class PhotoEditorPlugin extends Plugin {
                 hueSlider.setProgress((int) hsv[0]);
                 satSlider.setProgress((int) (hsv[1] * 100));
                 valSlider.setProgress((int) (hsv[2] * 100));
+                alphaSlider.setProgress(Color.alpha(c));
             });
             presetContainer.addView(swatch);
         }
@@ -1288,11 +1292,12 @@ public class PhotoEditorPlugin extends Plugin {
                 hsv[0] = hueSlider.getProgress();
                 hsv[1] = satSlider.getProgress() / 100f;
                 hsv[2] = valSlider.getProgress() / 100f;
-                currentColor[0] = Color.HSVToColor(hsv);
+                int alpha = alphaSlider.getProgress();
+                currentColor[0] = Color.HSVToColor(alpha, hsv);
                 boxBg.setColor(currentColor[0]);
                 previewBox.invalidate();
                 if (!hexInput.hasFocus()) {
-                    hexInput.setText(String.format("#%06X", (0xFFFFFF & currentColor[0])));
+                    hexInput.setText(String.format("#%08X", currentColor[0]));
                 }
             } catch (Exception e) {}
         };
@@ -1305,6 +1310,7 @@ public class PhotoEditorPlugin extends Plugin {
         hueSlider.setOnSeekBarChangeListener(sliderListener);
         satSlider.setOnSeekBarChangeListener(sliderListener);
         valSlider.setOnSeekBarChangeListener(sliderListener);
+        alphaSlider.setOnSeekBarChangeListener(sliderListener);
         
         hexInput.addTextChangedListener(new android.text.TextWatcher() {
             @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
@@ -1319,6 +1325,7 @@ public class PhotoEditorPlugin extends Plugin {
                         hueSlider.setProgress((int) hsv[0]);
                         satSlider.setProgress((int) (hsv[1] * 100));
                         valSlider.setProgress((int) (hsv[2] * 100));
+                        alphaSlider.setProgress(Color.alpha(c));
                     } catch (Exception ignored) {}
                 }
             }
@@ -1487,18 +1494,96 @@ public class PhotoEditorPlugin extends Plugin {
         dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
 
         LinearLayout layout = createBottomSheetContainer(context);
+        
+        // State variables
+        final int[] currentTextColor = {textColor};
+        final float[] currentTextSize = {28f};
+        final String[] currentFontFamily = {"sans-serif"};
+        final boolean[] isBold = {false};
+        final boolean[] isItalic = {false};
+        final boolean[] isUnderlined = {false};
+        final android.graphics.Typeface[] finalTypeface = {android.graphics.Typeface.DEFAULT};
+
+        final java.util.Map<String, String> fontPathMap = new java.util.HashMap<>();
+        String[] defaultFonts = {"sans-serif", "sans-serif-thin", "sans-serif-light", "sans-serif-medium", "sans-serif-black", "sans-serif-condensed", "sans-serif-condensed-light", "sans-serif-condensed-medium", "serif", "monospace", "serif-monospace", "casual", "cursive", "sans-serif-smallcaps"};
+        final java.util.List<String> fontList = new java.util.ArrayList<>(java.util.Arrays.asList(defaultFonts));
+        
+        class FontScanner {
+            void scan(java.io.File dir, int depth) {
+                if (depth > 2 || dir == null || !dir.exists() || !dir.isDirectory()) return;
+                java.io.File[] files = dir.listFiles();
+                if (files != null) {
+                    for (java.io.File f : files) {
+                        if (f.isDirectory()) {
+                            scan(f, depth + 1);
+                        } else if (f.isFile() && (f.getName().endsWith(".ttf") || f.getName().endsWith(".otf"))) {
+                            fontList.add(f.getName());
+                            fontPathMap.put(f.getName(), f.getAbsolutePath());
+                        }
+                    }
+                }
+            }
+        }
+        new FontScanner().scan(new java.io.File("/system/fonts"), 0);
+        new FontScanner().scan(new java.io.File(Environment.getExternalStorageDirectory(), "Fonts"), 0);
+        new FontScanner().scan(new java.io.File(Environment.getExternalStorageDirectory(), "Aliucord/fonts"), 0);
+
         EditText input = dialogInput(context, "Enter your text...");
         android.graphics.drawable.GradientDrawable inputBg = new android.graphics.drawable.GradientDrawable();
         inputBg.setColor(0xff1e1f22);
         inputBg.setCornerRadius(dp(8));
         inputBg.setStroke(dp(1), Color.parseColor("#3f4147"));
         input.setBackground(inputBg);
-        input.setTextColor(Color.WHITE);
+        input.setTextColor(currentTextColor[0]);
         input.setHintTextColor(Color.parseColor("#80848e"));
-        input.setTextSize(16f);
+        input.setTextSize(currentTextSize[0]);
         input.setMinLines(2);
         input.setGravity(Gravity.TOP | Gravity.START);
         input.setPadding(dp(12), dp(12), dp(12), dp(12));
+
+        Runnable updateTypeface = () -> {
+            int style = android.graphics.Typeface.NORMAL;
+            if (isBold[0] && isItalic[0]) style = android.graphics.Typeface.BOLD_ITALIC;
+            else if (isBold[0]) style = android.graphics.Typeface.BOLD;
+            else if (isItalic[0]) style = android.graphics.Typeface.ITALIC;
+            
+            try {
+                if (fontPathMap.containsKey(currentFontFamily[0])) {
+                    java.io.File f = new java.io.File(fontPathMap.get(currentFontFamily[0]));
+                    if (f.exists()) {
+                        finalTypeface[0] = android.graphics.Typeface.createFromFile(f);
+                        if (style != android.graphics.Typeface.NORMAL) {
+                            finalTypeface[0] = android.graphics.Typeface.create(finalTypeface[0], style);
+                        }
+                    } else {
+                        finalTypeface[0] = android.graphics.Typeface.create(currentFontFamily[0], style);
+                    }
+                } else if (currentFontFamily[0].endsWith(".ttf") || currentFontFamily[0].endsWith(".otf")) {
+                    java.io.File f = new java.io.File("/system/fonts/" + currentFontFamily[0]);
+                    if (f.exists()) {
+                        finalTypeface[0] = android.graphics.Typeface.createFromFile(f);
+                        if (style != android.graphics.Typeface.NORMAL) {
+                            finalTypeface[0] = android.graphics.Typeface.create(finalTypeface[0], style);
+                        }
+                    } else {
+                        finalTypeface[0] = android.graphics.Typeface.create(currentFontFamily[0], style);
+                    }
+                } else {
+                    finalTypeface[0] = android.graphics.Typeface.create(currentFontFamily[0], style);
+                }
+            } catch (Exception e) {
+                finalTypeface[0] = android.graphics.Typeface.create("sans-serif", style);
+            }
+            input.setTypeface(finalTypeface[0]);
+            input.setTextSize(currentTextSize[0]);
+            input.setTextColor(currentTextColor[0]);
+            
+            if (isUnderlined[0]) {
+                input.setPaintFlags(input.getPaintFlags() | android.graphics.Paint.UNDERLINE_TEXT_FLAG);
+            } else {
+                input.setPaintFlags(input.getPaintFlags() & ~android.graphics.Paint.UNDERLINE_TEXT_FLAG);
+            }
+        };
 
         LinearLayout.LayoutParams inputParams = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
@@ -1507,36 +1592,176 @@ public class PhotoEditorPlugin extends Plugin {
         inputParams.setMargins(0, 0, 0, dp(16));
         input.setLayoutParams(inputParams);
         layout.addView(input);
+        
+        // Wrap everything else in a ScrollView to prevent keyboard overlap
+        android.widget.ScrollView scrollView = new android.widget.ScrollView(context);
+        LinearLayout scrollContent = new LinearLayout(context);
+        scrollContent.setOrientation(LinearLayout.VERTICAL);
+        
+        // Font Selection Row
+        android.widget.AutoCompleteTextView fontSearch = new android.widget.AutoCompleteTextView(context);
+        
+        int bgColor = 0xff313338;
+        int textColorPrimary = Color.WHITE;
+        try {
+            android.util.TypedValue typedValue = new android.util.TypedValue();
+            int bgAttr = Utils.getResId("colorBackgroundFloating", "attr");
+            if (bgAttr != 0 && context.getTheme().resolveAttribute(bgAttr, typedValue, true)) {
+                bgColor = typedValue.data;
+            } else if (context.getTheme().resolveAttribute(android.R.attr.windowBackground, typedValue, true)) {
+                bgColor = typedValue.data;
+            }
+            
+            int textAttr = Utils.getResId("colorTextNormal", "attr");
+            if (textAttr != 0 && context.getTheme().resolveAttribute(textAttr, typedValue, true)) {
+                textColorPrimary = typedValue.data;
+            } else if (context.getTheme().resolveAttribute(android.R.attr.textColorPrimary, typedValue, true)) {
+                textColorPrimary = typedValue.data;
+            }
+        } catch (Exception ignored) {}
+        final int finalTextColor = textColorPrimary;
+        
+        fontSearch.setTextColor(textColorPrimary);
+        fontSearch.setHint("Search font (e.g., sans-serif)");
+        fontSearch.setHintTextColor(Color.GRAY);
+        fontSearch.setSingleLine(true);
+        fontSearch.setText("sans-serif");
+        fontSearch.setThreshold(0); // Show dropdown even when empty
+        fontSearch.setDropDownHeight(dp(150)); // Constrain height so it doesn't hide behind keyboard
+        fontSearch.setDropDownBackgroundDrawable(new android.graphics.drawable.ColorDrawable(bgColor)); // Match theme
+        fontSearch.setOnClickListener(v -> fontSearch.showDropDown());
+        fontSearch.setOnFocusChangeListener((v, hasFocus) -> { if (hasFocus) fontSearch.showDropDown(); });
+        android.widget.ArrayAdapter<String> adapter = new android.widget.ArrayAdapter<String>(context, android.R.layout.simple_dropdown_item_1line, fontList) {
+            @Override
+            public View getView(int position, View convertView, ViewGroup parent) {
+                TextView view = (TextView) super.getView(position, convertView, parent);
+                view.setTextColor(finalTextColor);
+                return view;
+            }
+        };
+        fontSearch.setAdapter(adapter);
+        
+        fontSearch.addTextChangedListener(new android.text.TextWatcher() {
+            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override public void onTextChanged(CharSequence s, int start, int before, int count) {}
+            @Override public void afterTextChanged(android.text.Editable s) {
+                currentFontFamily[0] = s.toString().trim();
+                updateTypeface.run();
+            }
+        });
+        fontSearch.setOnItemClickListener((parent, view, position, id) -> {
+            currentFontFamily[0] = adapter.getItem(position);
+            updateTypeface.run();
+        });
+        
+        LinearLayout.LayoutParams searchParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        searchParams.setMargins(0, 0, 0, dp(12));
+        scrollContent.addView(fontSearch, searchParams);
+        
+        // Style Toggles Row
+        LinearLayout styleTogglesRow = new LinearLayout(context);
+        styleTogglesRow.setOrientation(LinearLayout.HORIZONTAL);
+        styleTogglesRow.setGravity(Gravity.START | Gravity.CENTER_VERTICAL);
+        
+        // Bold Toggle
+        TextView boldToggle = new TextView(context);
+        boldToggle.setText("B");
+        boldToggle.setTextColor(Color.GRAY);
+        boldToggle.setTextSize(18f);
+        boldToggle.setTypeface(null, android.graphics.Typeface.BOLD);
+        boldToggle.setPadding(dp(8), dp(4), dp(16), dp(4));
+        boldToggle.setOnClickListener(v -> {
+            isBold[0] = !isBold[0];
+            boldToggle.setTextColor(isBold[0] ? Color.WHITE : Color.GRAY);
+            updateTypeface.run();
+        });
+        styleTogglesRow.addView(boldToggle);
+        
+        // Italic Toggle
+        TextView italicToggle = new TextView(context);
+        italicToggle.setText("I");
+        italicToggle.setTextColor(Color.GRAY);
+        italicToggle.setTextSize(18f);
+        italicToggle.setTypeface(null, android.graphics.Typeface.ITALIC);
+        italicToggle.setPadding(dp(16), dp(4), dp(16), dp(4));
+        italicToggle.setOnClickListener(v -> {
+            isItalic[0] = !isItalic[0];
+            italicToggle.setTextColor(isItalic[0] ? Color.WHITE : Color.GRAY);
+            updateTypeface.run();
+        });
+        styleTogglesRow.addView(italicToggle);
 
-        TextView colorLabel = new TextView(context);
-        colorLabel.setText("Color");
-        colorLabel.setTextColor(Color.parseColor("#b5bac1"));
-        colorLabel.setTextSize(12f);
-        colorLabel.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
-        colorLabel.setPadding(0, 0, 0, dp(8));
-        layout.addView(colorLabel);
-
-        LinearLayout colorRow = new LinearLayout(context);
-        colorRow.setOrientation(LinearLayout.HORIZONTAL);
-        colorRow.setGravity(Gravity.CENTER_VERTICAL);
-        List<View> textColorSwatches = new ArrayList<>();
-        for (int color : COLORS) {
-            View swatch = colorSwatch(context, color, view -> {
-                textColor = color;
-                selectColorOnly(textColorSwatches, color);
+        // Underline Toggle
+        TextView underlineToggle = new TextView(context);
+        underlineToggle.setText("U");
+        underlineToggle.setTextColor(Color.GRAY);
+        underlineToggle.setTextSize(18f);
+        underlineToggle.setPaintFlags(underlineToggle.getPaintFlags() | android.graphics.Paint.UNDERLINE_TEXT_FLAG);
+        underlineToggle.setPadding(dp(16), dp(4), dp(16), dp(4));
+        underlineToggle.setOnClickListener(v -> {
+            isUnderlined[0] = !isUnderlined[0];
+            underlineToggle.setTextColor(isUnderlined[0] ? Color.WHITE : Color.GRAY);
+            updateTypeface.run();
+        });
+        styleTogglesRow.addView(underlineToggle);
+        
+        LinearLayout.LayoutParams togglesRowParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        togglesRowParams.setMargins(0, 0, 0, dp(12));
+        scrollContent.addView(styleTogglesRow, togglesRowParams);
+        
+        // Size & Color Row
+        LinearLayout styleRow = new LinearLayout(context);
+        styleRow.setOrientation(LinearLayout.HORIZONTAL);
+        styleRow.setGravity(Gravity.CENTER_VERTICAL);
+        styleRow.setPadding(0, 0, 0, dp(16));
+        
+        TextView sizeLabel = new TextView(context);
+        sizeLabel.setText("Size " + (int) currentTextSize[0]);
+        sizeLabel.setTextColor(Color.parseColor("#b5bac1"));
+        sizeLabel.setTextSize(14f);
+        sizeLabel.setMinimumWidth(dp(65)); // Prevent layout jumping
+        styleRow.addView(sizeLabel);
+        
+        android.widget.SeekBar sizeSlider = new android.widget.SeekBar(context);
+        sizeSlider.setMax(110); // 10 to 120
+        sizeSlider.setProgress((int) currentTextSize[0] - 10);
+        sizeSlider.setOnSeekBarChangeListener(new android.widget.SeekBar.OnSeekBarChangeListener() {
+            @Override public void onProgressChanged(android.widget.SeekBar seekBar, int progress, boolean fromUser) {
+                currentTextSize[0] = progress + 10f;
+                sizeLabel.setText("Size " + (int) currentTextSize[0]);
+                updateTypeface.run();
+            }
+            @Override public void onStartTrackingTouch(android.widget.SeekBar seekBar) {}
+            @Override public void onStopTrackingTouch(android.widget.SeekBar seekBar) {}
+        });
+        LinearLayout.LayoutParams sliderParams = new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
+        styleRow.addView(sizeSlider, sliderParams);
+        
+        View colorBtn = colorSwatch(context, currentTextColor[0], null);
+        colorBtn.setOnClickListener(v -> {
+            showColorPickerDialog(context, editorView, editor, currentTextColor[0], newColor -> {
+                currentTextColor[0] = newColor;
+                textColor = newColor; // Also sync global text color
+                setColorSwatchSelected(colorBtn, newColor, true);
+                updateTypeface.run();
             });
-            swatch.setTag(color);
-            textColorSwatches.add(swatch);
-            colorRow.addView(swatch);
-        }
-        selectColorOnly(textColorSwatches, textColor);
-        LinearLayout.LayoutParams colorParams = new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        );
-        colorParams.setMargins(0, 0, 0, dp(18));
-        layout.addView(colorRow, colorParams);
+        });
+        LinearLayout.LayoutParams colorBtnParams = new LinearLayout.LayoutParams(dp(32), dp(32));
+        colorBtnParams.setMargins(dp(12), 0, 0, 0);
+        colorBtn.setLayoutParams(colorBtnParams);
+        styleRow.addView(colorBtn);
+        
+        scrollContent.addView(styleRow);
+        
+        scrollView.addView(scrollContent);
+        LinearLayout.LayoutParams scrollParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        // We use weight=1f so that if the keyboard pushes it, it shrinks and becomes scrollable
+        scrollParams.weight = 1f;
+        layout.addView(scrollView, scrollParams);
 
+        updateTypeface.run();
+
+        // Buttons
         LinearLayout buttons = new LinearLayout(context);
         buttons.setOrientation(LinearLayout.HORIZONTAL);
         buttons.setGravity(Gravity.RIGHT);
@@ -1569,10 +1794,10 @@ public class PhotoEditorPlugin extends Plugin {
             if (!text.isEmpty()) {
                 try {
                     editor.setBrushDrawingMode(false);
-                    addTextOverlay(editorView, text, textColor);
+                    addTextOverlay(editorView, text, currentTextColor[0], finalTypeface[0], currentTextSize[0], isUnderlined[0]);
                 } catch (Throwable t) {
                     logger.error("Failed to add text to canvas", t);
-                    Toast.makeText(context, "Failed to add text: " + t.getMessage(), Toast.LENGTH_LONG).show();
+                    android.widget.Toast.makeText(context, "Failed to add text: " + t.getMessage(), android.widget.Toast.LENGTH_LONG).show();
                 }
             }
             dialog.dismiss();
@@ -2281,14 +2506,17 @@ public class PhotoEditorPlugin extends Plugin {
         }
     }
 
-        private void addTextOverlay(PhotoEditorView editorView, String text, int color) {
+    private void addTextOverlay(PhotoEditorView editorView, String text, int color, android.graphics.Typeface typeface, float textSize, boolean isUnderlined) {
         TextView textView = new TextView(editorView.getContext());
         textView.setTag(OVERLAY_TEXT);
         textView.setText(text);
         textView.setTextColor(color);
-        textView.setTextSize(28f);
+        textView.setTextSize(textSize);
         textView.setGravity(Gravity.CENTER);
-        textView.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
+        textView.setTypeface(typeface);
+        if (isUnderlined) {
+            textView.setPaintFlags(textView.getPaintFlags() | android.graphics.Paint.UNDERLINE_TEXT_FLAG);
+        }
         textView.setShadowLayer(dp(2), dp(1), dp(1), 0xcc000000);
         textView.setPadding(dp(8), dp(4), dp(8), dp(4));
         addManualOverlay(editorView, textView);

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -96,7 +96,7 @@ public class PhotoEditorPlugin extends Plugin {
         void onSpoilerToggled(boolean isSpoiler);
     }
 
-    private View createToolbar(Context context, PhotoEditor editor, PhotoEditorView editorView, Dialog dialog, Attachment<?>[] currentAttachment, EditRequest editRequest) {
+    private View createToolbar(Context context, PhotoEditor editor, PhotoEditorView editorView, Dialog dialog, Attachment<?>[] currentAttachment, EditRequest editRequest, PhotoFilter[] sessionFilter) {
         LinearLayout rootContainer = new LinearLayout(context);
         rootContainer.setOrientation(LinearLayout.VERTICAL);
         rootContainer.setBackgroundColor(0xff1e1f22);
@@ -104,23 +104,23 @@ public class PhotoEditorPlugin extends Plugin {
             rootContainer.setElevation(dp(8));
         }
 
-        FrameLayout subToolbarContainer = new FrameLayout(context);
-        subToolbarContainer.setBackgroundColor(0xff2b2d31);
-        subToolbarContainer.setVisibility(View.GONE);
-        rootContainer.addView(subToolbarContainer, new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        ));
-
         android.widget.HorizontalScrollView mainScroll = new android.widget.HorizontalScrollView(context);
         mainScroll.setHorizontalScrollBarEnabled(false);
-
         LinearLayout mainToolbar = new LinearLayout(context);
         mainToolbar.setOrientation(LinearLayout.HORIZONTAL);
         mainToolbar.setGravity(Gravity.CENTER_VERTICAL);
-        mainToolbar.setPadding(dp(8), dp(7), dp(8), dp(7));
+        mainToolbar.setPadding(dp(8), dp(12), dp(8), dp(12));
         mainScroll.addView(mainToolbar, new android.widget.HorizontalScrollView.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        FrameLayout subToolbarContainer = new FrameLayout(context);
+        subToolbarContainer.setVisibility(View.GONE);
+        subToolbarContainer.setBackgroundColor(0xff2b2d31);
+        
+        rootContainer.addView(subToolbarContainer, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
         ));
         rootContainer.addView(mainScroll, new LinearLayout.LayoutParams(
@@ -133,8 +133,6 @@ public class PhotoEditorPlugin extends Plugin {
         List<View> sizeButtons = new ArrayList<>();
         List<View> colorSwatches = new ArrayList<>();
         List<View> filterButtons = new ArrayList<>();
-
-        PhotoFilter[] sessionFilter = {PhotoFilter.NONE};
 
         // --- DRAW SUB-TOOLBAR ---
         android.widget.HorizontalScrollView drawScroll = new android.widget.HorizontalScrollView(context);
@@ -201,23 +199,6 @@ public class PhotoEditorPlugin extends Plugin {
             drawToolbar.addView(swatch);
         }
 
-        drawToolbar.addView(groupSeparator(context));
-        drawToolbar.addView(iconButton(context, "Undo", "material_ic_keyboard_arrow_left_black_24dp", v -> {
-            boolean undidOverlay = false;
-            for (int i = editorView.getChildCount() - 1; i >= 0; i--) {
-                View child = editorView.getChildAt(i);
-                Object tag = child.getTag();
-                if (OVERLAY_IMAGE.equals(tag) || OVERLAY_TEXT.equals(tag) || OVERLAY_EMOJI.equals(tag)) {
-                    editorView.removeViewAt(i);
-                    undidOverlay = true;
-                    break;
-                }
-            }
-            if (!undidOverlay) editor.undo();
-        }));
-        drawToolbar.addView(iconButton(context, "Redo", "material_ic_keyboard_arrow_right_black_24dp", v -> editor.redo()));
-        drawToolbar.addView(iconButton(context, "Clear", "ic_close_24dp", v -> clearAllEditorOverlays(editor, editorView)));
-
         // --- FILTER SUB-TOOLBAR ---
         android.widget.HorizontalScrollView filterScroll = new android.widget.HorizontalScrollView(context);
         filterScroll.setHorizontalScrollBarEnabled(false);
@@ -248,6 +229,30 @@ public class PhotoEditorPlugin extends Plugin {
         }
 
         // --- MAIN TOOLBAR ---
+        mainToolbar.addView(iconButton(context, "Undo", "ic_reply_24dp", v -> {
+            boolean undidOverlay = false;
+            for (int i = editorView.getChildCount() - 1; i >= 0; i--) {
+                View child = editorView.getChildAt(i);
+                Object tag = child.getTag();
+                if (OVERLAY_IMAGE.equals(tag) || OVERLAY_TEXT.equals(tag) || OVERLAY_EMOJI.equals(tag)) {
+                    editorView.removeViewAt(i);
+                    undidOverlay = true;
+                    break;
+                }
+            }
+            if (!undidOverlay) editor.undo();
+        }));
+
+        View redoMainBtn = iconButton(context, "Redo", "ic_reply_24dp", v -> editor.redo());
+        if (redoMainBtn instanceof android.view.ViewGroup && ((android.view.ViewGroup) redoMainBtn).getChildCount() > 0) {
+            ((android.view.ViewGroup) redoMainBtn).getChildAt(0).setScaleX(-1f);
+        }
+        mainToolbar.addView(redoMainBtn);
+
+        mainToolbar.addView(iconButton(context, "Reset", "ic_refresh_white_a60_24dp", v -> clearAllEditorOverlays(editor, editorView)));
+
+        mainToolbar.addView(groupSeparator(context));
+
         View drawMainBtn = iconButton(context, "Draw", "ic_edit_24dp", null);
         drawMainBtn.setOnClickListener(v -> {
             selectOnly(mainButtons, drawMainBtn);
@@ -261,7 +266,7 @@ public class PhotoEditorPlugin extends Plugin {
         mainButtons.add(drawMainBtn);
         mainToolbar.addView(drawMainBtn);
 
-        View textMainBtn = iconButton(context, "Text", "ic_text_channel_white_24dp", v -> showTextDialog(context, editor, editorView));
+        View textMainBtn = iconButton(context, "Text", "ic_text_image_24dp", v -> showTextDialog(context, editor, editorView));
         mainToolbar.addView(textMainBtn);
 
         View emojiMainBtn = iconButton(context, "Emoji", "ic_emoji_24dp", v -> showDiscordEmojiPicker(context, editor, editorView));
@@ -293,10 +298,6 @@ public class PhotoEditorPlugin extends Plugin {
         mainButtons.add(filterMainBtn);
         mainToolbar.addView(filterMainBtn);
 
-        mainToolbar.addView(groupSeparator(context));
-        View saveBtn = iconButton(context, "Save", "ic_check_circle_24dp", v -> saveImage(context, editor, editorView, currentAttachment, editRequest, dialog, sessionFilter));
-        mainToolbar.addView(saveBtn);
-
         // Initial state
         setToolbarButtonSelected(drawMainBtn, true);
         subToolbarContainer.addView(drawScroll);
@@ -304,6 +305,8 @@ public class PhotoEditorPlugin extends Plugin {
         setToolbarButtonSelected(penButton, true);
         setToolbarButtonSelected(brushSize <= 12 ? thinButton : thickButton, true);
         selectColorOnly(colorSwatches, brushColor);
+        editor.setBrushDrawingMode(true);
+        applyBrush(editor);
 
         return rootContainer;
     }
@@ -719,9 +722,11 @@ public class PhotoEditorPlugin extends Plugin {
     }
 
     private void openEditor(Activity passedActivity, Attachment<?> attachment, EditRequest editRequest, SelectionAggregator<?> aggregator) {
-        Activity activity = passedActivity;
-        if (activity == null || activity.isFinishing() || (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1 && activity.isDestroyed())) {
+        final Activity activity;
+        if (passedActivity == null || passedActivity.isFinishing() || (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1 && passedActivity.isDestroyed())) {
             activity = getRealActivity();
+        } else {
+            activity = passedActivity;
         }
         if (activity == null || activity.isFinishing() || (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1 && activity.isDestroyed())) {
             android.widget.Toast.makeText(getRealActivity(), "Could not open image editor (activity null or destroyed)", android.widget.Toast.LENGTH_SHORT).show();
@@ -741,6 +746,7 @@ public class PhotoEditorPlugin extends Plugin {
                 .build();
 
         final Attachment<?>[] currentAttachment = {attachment};
+        final PhotoFilter[] sessionFilter = {PhotoFilter.NONE};
 
         FrameLayout spoilerOverlay = new FrameLayout(activity);
         spoilerOverlay.setBackgroundColor(0x99000000);
@@ -801,6 +807,20 @@ public class PhotoEditorPlugin extends Plugin {
                 }
             }
         });
+        
+        android.widget.ImageView saveBtn = new android.widget.ImageView(activity);
+        int saveId = Utils.getResId("ic_check_white_24dp", "drawable");
+        saveBtn.setImageResource(saveId != 0 ? saveId : android.R.drawable.ic_menu_save);
+        saveBtn.setColorFilter(Color.WHITE);
+        saveBtn.setPadding(dp(8), dp(8), dp(8), dp(8));
+        addRippleBorderless(saveBtn);
+        addPressAnimation(saveBtn);
+        saveBtn.setOnClickListener(v -> saveImage(activity, editor, editorView, currentAttachment, editRequest, dialog, sessionFilter));
+        
+        LinearLayout.LayoutParams saveParams = new LinearLayout.LayoutParams(dp(40), dp(40));
+        saveParams.setMargins(dp(8), 0, 0, 0);
+        ((LinearLayout) header).addView(saveBtn, saveParams);
+
         content.addView(header, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
@@ -832,7 +852,7 @@ public class PhotoEditorPlugin extends Plugin {
                 Gravity.CENTER
         ));
 
-        content.addView(createToolbar(activity, editor, editorView, dialog, currentAttachment, editRequest), new LinearLayout.LayoutParams(
+        content.addView(createToolbar(activity, editor, editorView, dialog, currentAttachment, editRequest, sessionFilter), new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
         ));

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorPlugin.java
@@ -96,7 +96,7 @@ public class PhotoEditorPlugin extends Plugin {
         void onSpoilerToggled(boolean isSpoiler);
     }
 
-    private View createToolbar(Context context, PhotoEditor editor, PhotoEditorView editorView, Dialog dialog, Attachment<?>[] currentAttachment, EditRequest editRequest, PhotoFilter[] sessionFilter) {
+    private View createToolbar(Context context, PhotoEditor editor, PhotoEditorView editorView, Dialog dialog, Attachment<?>[] currentAttachment, EditRequest editRequest, PhotoFilter[] sessionFilter, boolean[] isCustomFilter, float[] customFilterValues) {
         LinearLayout rootContainer = new LinearLayout(context);
         rootContainer.setOrientation(LinearLayout.VERTICAL);
         rootContainer.setBackgroundColor(0xff1e1f22);
@@ -245,6 +245,14 @@ public class PhotoEditorPlugin extends Plugin {
             filterButtons.add(fBtn);
             fBtn.setOnClickListener(v -> {
                 selectOnly(filterButtons, fBtn);
+                isCustomFilter[0] = false;
+                for (int i=0; i<editorView.getChildCount(); i++) {
+                    android.view.View child = editorView.getChildAt(i);
+                    if (child.getClass().getName().contains("ImageFilterView")) {
+                        child.setVisibility(android.view.View.VISIBLE);
+                    }
+                }
+                editorView.getSource().clearColorFilter();
                 sessionFilter[0] = filter;
                 selectedFilter = filter;
                 editor.setFilterEffect(filter);
@@ -254,6 +262,21 @@ public class PhotoEditorPlugin extends Plugin {
                     Toast.makeText(context, "This filter requires Android 7.0+ to save properly", Toast.LENGTH_LONG).show();
             });
             filterToolbar.addView(fBtn);
+            
+            if (filter == PhotoFilter.NONE) {
+                View customBtn = iconButton(context, "Custom", null, null);
+                customBtn.setTag("CUSTOM");
+                filterButtons.add(customBtn);
+                customBtn.setOnClickListener(v -> {
+                    selectOnly(filterButtons, customBtn);
+                    isCustomFilter[0] = true;
+                    editor.setFilterEffect(PhotoFilter.NONE);
+                    sessionFilter[0] = PhotoFilter.NONE;
+                    selectedFilter = PhotoFilter.NONE;
+                    showCustomFilterDialog(context, editorView, customFilterValues);
+                });
+                filterToolbar.addView(customBtn);
+            }
         }
 
         // --- MAIN TOOLBAR ---
@@ -359,7 +382,11 @@ public class PhotoEditorPlugin extends Plugin {
         View cropMainBtn = iconButton(context, "Crop", "ucrop_ic_crop", v -> showCropDialog(context, editorView));
         mainToolbar.addView(cropMainBtn);
 
-        View filterMainBtn = iconButton(context, "Filter", "ic_filter_list_grey_24dp", null);
+        int filterIconId = Utils.getResId("ic_flare_24dp", "drawable");
+        if (filterIconId == 0) filterIconId = Utils.getResId("ic_auto_fix_high", "drawable");
+        if (filterIconId == 0) filterIconId = Utils.getResId("ic_filter_list_grey_24dp", "drawable");
+        String filterIconName = filterIconId != 0 ? context.getResources().getResourceEntryName(filterIconId) : "ic_filter_list_grey_24dp";
+        View filterMainBtn = iconButton(context, "Filter", filterIconName, null);
         filterMainBtn.setOnClickListener(v -> {
             selectOnly(mainButtons, filterMainBtn);
             subToolbarContainer.removeAllViews();
@@ -367,7 +394,8 @@ public class PhotoEditorPlugin extends Plugin {
             subToolbarContainer.setVisibility(View.VISIBLE);
             editor.setBrushDrawingMode(false);
             for (int i=0; i<filterButtons.size(); i++) {
-                if (filterButtons.get(i).getTag() == sessionFilter[0]) {
+                Object tag = filterButtons.get(i).getTag();
+                if ((isCustomFilter[0] && "CUSTOM".equals(tag)) || (!isCustomFilter[0] && tag == sessionFilter[0])) {
                     selectOnly(filterButtons, filterButtons.get(i));
                     break;
                 }
@@ -823,6 +851,8 @@ public class PhotoEditorPlugin extends Plugin {
 
         final Attachment<?>[] currentAttachment = {attachment};
         final PhotoFilter[] sessionFilter = {PhotoFilter.NONE};
+        final boolean[] isCustomFilter = {false};
+        final float[] customFilterValues = new float[]{0f, 1f, 1f, 0f, 0f, 0f}; // Brightness, Contrast, Saturation, Hue, Temp, Tint
 
         FrameLayout spoilerOverlay = new FrameLayout(activity);
         spoilerOverlay.setBackgroundColor(0x99000000);
@@ -891,7 +921,7 @@ public class PhotoEditorPlugin extends Plugin {
         saveBtn.setPadding(dp(8), dp(8), dp(8), dp(8));
         addRippleBorderless(saveBtn);
         addPressAnimation(saveBtn);
-        saveBtn.setOnClickListener(v -> saveImage(activity, editor, editorView, currentAttachment, editRequest, dialog, sessionFilter));
+        saveBtn.setOnClickListener(v -> saveImage(activity, editor, editorView, currentAttachment, editRequest, dialog, sessionFilter, isCustomFilter, customFilterValues));
         
         LinearLayout.LayoutParams saveParams = new LinearLayout.LayoutParams(dp(40), dp(40));
         saveParams.setMargins(dp(8), 0, 0, 0);
@@ -928,7 +958,7 @@ public class PhotoEditorPlugin extends Plugin {
                 Gravity.CENTER
         ));
 
-        content.addView(createToolbar(activity, editor, editorView, dialog, currentAttachment, editRequest, sessionFilter), new LinearLayout.LayoutParams(
+        content.addView(createToolbar(activity, editor, editorView, dialog, currentAttachment, editRequest, sessionFilter, isCustomFilter, customFilterValues), new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
         ));
@@ -1517,8 +1547,10 @@ public class PhotoEditorPlugin extends Plugin {
                         if (f.isDirectory()) {
                             scan(f, depth + 1);
                         } else if (f.isFile() && (f.getName().endsWith(".ttf") || f.getName().endsWith(".otf"))) {
-                            fontList.add(f.getName());
-                            fontPathMap.put(f.getName(), f.getAbsolutePath());
+                            String name = f.getName();
+                            String cleanName = name.substring(0, name.lastIndexOf('.'));
+                            fontList.add(cleanName);
+                            fontPathMap.put(cleanName, f.getAbsolutePath());
                         }
                     }
                 }
@@ -2897,7 +2929,7 @@ public class PhotoEditorPlugin extends Plugin {
         }
     }
 
-        private void saveImage(Context context, PhotoEditor editor, PhotoEditorView editorView, Attachment<?>[] currentAttachment, EditRequest editRequest, Dialog dialog, PhotoFilter[] sessionFilter) {
+    private void saveImage(Context context, PhotoEditor editor, PhotoEditorView editorView, Attachment<?>[] currentAttachment, EditRequest editRequest, Dialog dialog, PhotoFilter[] sessionFilter, boolean[] isCustomFilter, float[] customFilterValues) {
         try {
             editor.clearHelperBox();
 
@@ -2958,7 +2990,7 @@ public class PhotoEditorPlugin extends Plugin {
             Canvas canvas = new Canvas(saveBitmap);
 
             Paint srcPaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.FILTER_BITMAP_FLAG);
-            float[] matrix = getColorMatrixForFilter(activeFilter);
+            float[] matrix = isCustomFilter != null && isCustomFilter[0] ? buildCustomMatrix(customFilterValues) : getColorMatrixForFilter(activeFilter);
             if (matrix != null) {
                 srcPaint.setColorFilter(new android.graphics.ColorMatrixColorFilter(matrix));
             }
@@ -3241,6 +3273,170 @@ public class PhotoEditorPlugin extends Plugin {
             }
             return false;
         });
+    }
+
+    private float[] buildCustomMatrix(float[] values) {
+        float brightness = values[0];
+        float contrast = values[1];
+        float saturation = values[2];
+        float hue = values[3];
+        float temp = values[4];
+        float tint = values[5];
+
+        android.graphics.ColorMatrix cm = new android.graphics.ColorMatrix();
+        
+        // Brightness & Contrast
+        float t = (1f - contrast) * 128f + brightness;
+        android.graphics.ColorMatrix cmContrast = new android.graphics.ColorMatrix(new float[]{
+            contrast, 0, 0, 0, t,
+            0, contrast, 0, 0, t,
+            0, 0, contrast, 0, t,
+            0, 0, 0, 1, 0
+        });
+        cm.postConcat(cmContrast);
+
+        // Saturation
+        android.graphics.ColorMatrix cmSat = new android.graphics.ColorMatrix();
+        cmSat.setSaturation(saturation);
+        cm.postConcat(cmSat);
+
+        // Hue
+        if (hue != 0f) {
+            float cos = (float) Math.cos(hue * Math.PI / 180f);
+            float sin = (float) Math.sin(hue * Math.PI / 180f);
+            float lumR = 0.213f, lumG = 0.715f, lumB = 0.072f;
+            android.graphics.ColorMatrix cmHue = new android.graphics.ColorMatrix(new float[]{
+                lumR + cos * (1 - lumR) + sin * (-lumR), lumG + cos * (-lumG) + sin * (-lumG), lumB + cos * (-lumB) + sin * (1 - lumB), 0, 0,
+                lumR + cos * (-lumR) + sin * (0.143f), lumG + cos * (1 - lumG) + sin * (0.140f), lumB + cos * (-lumB) + sin * (-0.283f), 0, 0,
+                lumR + cos * (-lumR) + sin * (-(1 - lumR)), lumG + cos * (-lumG) + sin * (lumG), lumB + cos * (1 - lumB) + sin * (lumB), 0, 0,
+                0, 0, 0, 1, 0
+            });
+            cm.postConcat(cmHue);
+        }
+
+        // Temperature (Warm/Cool) & Tint (Green/Magenta)
+        if (temp != 0f || tint != 0f) {
+            float rTemp = temp > 0 ? temp * 0.1f : 0;
+            float bTemp = temp < 0 ? -temp * 0.1f : 0;
+            float gTint = tint > 0 ? tint * 0.1f : 0;
+            float rTint = tint < 0 ? -tint * 0.1f : 0;
+            float bTint = tint < 0 ? -tint * 0.1f : 0;
+            
+            android.graphics.ColorMatrix cmTempTint = new android.graphics.ColorMatrix(new float[]{
+                1f + rTemp + rTint, 0, 0, 0, 0,
+                0, 1f + gTint, 0, 0, 0,
+                0, 0, 1f + bTemp + bTint, 0, 0,
+                0, 0, 0, 1, 0
+            });
+            cm.postConcat(cmTempTint);
+        }
+
+        return cm.getArray();
+    }
+
+    private void showCustomFilterDialog(Context context, PhotoEditorView editorView, float[] customFilterValues) {
+        Dialog dialog = new Dialog(context);
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+
+        LinearLayout layout = createBottomSheetContainer(context);
+        android.widget.ScrollView scrollContent = new android.widget.ScrollView(context);
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+
+        Runnable updateFilter = () -> {
+            for (int i=0; i<editorView.getChildCount(); i++) {
+                android.view.View child = editorView.getChildAt(i);
+                if (child.getClass().getName().contains("ImageFilterView")) {
+                    child.setVisibility(android.view.View.GONE);
+                }
+            }
+            float[] matrix = buildCustomMatrix(customFilterValues);
+            editorView.getSource().setColorFilter(new android.graphics.ColorMatrixColorFilter(matrix));
+        };
+
+        String[] labels = {"Brightness", "Contrast", "Saturation", "Hue", "Temperature", "Tint"};
+        float[] mins = {-100f, 0f, 0f, -180f, -50f, -50f};
+        float[] maxs = {100f, 2f, 2f, 180f, 50f, 50f};
+        float[] defaults = {0f, 1f, 1f, 0f, 0f, 0f};
+
+        for (int i = 0; i < 6; i++) {
+            final int index = i;
+            LinearLayout row = new LinearLayout(context);
+            row.setOrientation(LinearLayout.VERTICAL);
+            row.setPadding(0, 0, 0, dp(16));
+
+            LinearLayout header = new LinearLayout(context);
+            header.setOrientation(LinearLayout.HORIZONTAL);
+            
+            TextView label = new TextView(context);
+            label.setText(labels[i]);
+            label.setTextColor(Color.WHITE);
+            label.setTextSize(14f);
+            
+            TextView valueText = new TextView(context);
+            valueText.setText(String.format(java.util.Locale.US, "%.2f", customFilterValues[i]));
+            valueText.setTextColor(Color.GRAY);
+            valueText.setTextSize(12f);
+            
+            LinearLayout.LayoutParams lblParams = new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
+            header.addView(label, lblParams);
+            header.addView(valueText);
+            
+            row.addView(header);
+
+            android.widget.SeekBar slider = new android.widget.SeekBar(context);
+            slider.setMax(200); // Normalize to 0-200
+            
+            float current = customFilterValues[i];
+            float range = maxs[i] - mins[i];
+            int progress = (int) (((current - mins[i]) / range) * 200f);
+            slider.setProgress(progress);
+
+            slider.setOnSeekBarChangeListener(new android.widget.SeekBar.OnSeekBarChangeListener() {
+                @Override
+                public void onProgressChanged(android.widget.SeekBar seekBar, int prog, boolean fromUser) {
+                    if (fromUser) {
+                        float val = mins[index] + ((float) prog / 200f) * range;
+                        customFilterValues[index] = val;
+                        valueText.setText(String.format(java.util.Locale.US, "%.2f", val));
+                        updateFilter.run();
+                    }
+                }
+                @Override public void onStartTrackingTouch(android.widget.SeekBar seekBar) {}
+                @Override public void onStopTrackingTouch(android.widget.SeekBar seekBar) {}
+            });
+            row.addView(slider);
+            content.addView(row);
+        }
+        
+        TextView resetBtn = new TextView(context);
+        resetBtn.setText("Reset Custom Filter");
+        resetBtn.setTextColor(0xffda373c);
+        resetBtn.setTextSize(14f);
+        resetBtn.setGravity(Gravity.CENTER);
+        resetBtn.setPadding(dp(16), dp(16), dp(16), dp(16));
+        resetBtn.setOnClickListener(v -> {
+            System.arraycopy(defaults, 0, customFilterValues, 0, defaults.length);
+            updateFilter.run();
+            dialog.dismiss();
+            showCustomFilterDialog(context, editorView, customFilterValues); // Reopen to refresh sliders
+        });
+        content.addView(resetBtn);
+
+        scrollContent.addView(content);
+        layout.addView(scrollContent, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                dp(300)
+        ));
+
+        dialog.setContentView(layout);
+        Window window = dialog.getWindow();
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+            window.setGravity(Gravity.BOTTOM);
+            window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        }
+        dialog.show();
     }
 
     private interface EditRequest {

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSaver.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSaver.java
@@ -1,0 +1,232 @@
+package com.aliucord.plugins.photoeditor;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.ImageDecoder;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.graphics.drawable.ColorDrawable;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Environment;
+import android.text.InputType;
+import android.view.Gravity;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.widget.AppCompatTextView;
+import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import com.aliucord.Utils;
+import com.aliucord.annotations.AliucordPlugin;
+import com.aliucord.entities.Plugin;
+import com.aliucord.patcher.Hook;
+import com.aliucord.patcher.InsteadHook;
+import com.aliucord.patcher.PreHook;
+import com.aliucord.utils.DimenUtils;
+import com.discord.api.channel.Channel;
+import com.discord.api.message.attachment.MessageAttachment;
+import com.discord.api.message.attachment.MessageAttachmentType;
+import com.discord.api.sticker.Sticker;
+import com.discord.models.domain.emoji.Emoji;
+import com.discord.models.message.Message;
+import com.discord.stores.StoreStream;
+import com.discord.utilities.stickers.StickerUtils;
+import com.discord.widgets.chat.input.WidgetChatInputAttachments;
+import com.discord.widgets.chat.input.attachments.AttachmentBottomSheet;
+import com.discord.widgets.chat.input.emoji.EmojiPickerContextType;
+import com.discord.widgets.chat.input.emoji.EmojiPickerNavigator;
+import com.discord.widgets.chat.input.sticker.StickerPickerViewModel;
+import com.discord.widgets.chat.input.sticker.WidgetStickerPickerSheet;
+import com.discord.widgets.chat.list.adapter.WidgetChatListAdapterItemAttachment;
+import com.discord.widgets.chat.list.entries.AttachmentEntry;
+import com.discord.widgets.chat.list.entries.ChatListEntry;
+import com.discord.widgets.media.WidgetMedia;
+import com.lytefast.flexinput.fragment.FlexInputFragment;
+import com.lytefast.flexinput.model.Attachment;
+import com.lytefast.flexinput.utils.SelectionAggregator;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import de.robv.android.xposed.XposedBridge;
+import ja.burhanrashid52.photoeditor.PhotoEditor;
+import ja.burhanrashid52.photoeditor.PhotoEditorView;
+import ja.burhanrashid52.photoeditor.PhotoFilter;
+import ja.burhanrashid52.photoeditor.shape.ShapeBuilder;
+import kotlin.Unit;
+
+final class PhotoEditorSaver {
+    private PhotoEditorSaver() {}
+
+    static void save(PhotoEditorPlugin owner, Context context, PhotoEditor editor, PhotoEditorView editorView, Attachment<?>[] currentAttachment, PhotoEditorPlugin.EditRequest editRequest, Dialog dialog, PhotoFilter[] sessionFilter, boolean[] isCustomFilter, float[] customFilterValues) {
+        try {
+            editor.clearHelperBox();
+
+            // Obtain source bitmap
+            Bitmap srcBitmap = null;
+            android.graphics.drawable.Drawable srcDrawable = editorView.getSource().getDrawable();
+            if (srcDrawable instanceof android.graphics.drawable.BitmapDrawable) {
+                srcBitmap = ((android.graphics.drawable.BitmapDrawable) srcDrawable).getBitmap();
+            }
+            if (srcBitmap == null || srcBitmap.getWidth() <= 0 || srcBitmap.getHeight() <= 0) {
+                throw new IllegalStateException("Invalid source bitmap");
+            }
+
+            PhotoFilter activeFilter = (sessionFilter != null && sessionFilter[0] != null)
+                    ? sessionFilter[0] : PhotoFilter.NONE;
+            boolean isGlOnly = owner.isGlOnlyFilter(activeFilter);
+
+            if (isGlOnly && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                android.view.SurfaceView glView = null;
+                for (int i = 0; i < editorView.getChildCount(); i++) {
+                    View child = editorView.getChildAt(i);
+                    if (child instanceof android.view.SurfaceView) {
+                        glView = (android.view.SurfaceView) child;
+                        break;
+                    }
+                }
+                if (glView != null && glView.getWidth() > 0 && glView.getHeight() > 0) {
+                    Bitmap glBitmap = Bitmap.createBitmap(glView.getWidth(), glView.getHeight(), Bitmap.Config.ARGB_8888);
+                    android.view.PixelCopy.request(glView, glBitmap, copyResult -> {
+                        if (copyResult == android.view.PixelCopy.SUCCESS) {
+                            Canvas canvas = new Canvas(glBitmap);
+                            // Draw overlays on top, unscaled (since glView and children share the same layout space)
+                            for (int i = 0; i < editorView.getChildCount(); i++) {
+                                View child = editorView.getChildAt(i);
+                                if (child == editorView.getSource() || child instanceof android.view.SurfaceView) continue;
+                                canvas.save();
+                                canvas.translate(child.getX(), child.getY());
+                                float pivX = child.getPivotX();
+                                float pivY = child.getPivotY();
+                                canvas.scale(child.getScaleX(), child.getScaleY(), pivX, pivY);
+                                if (child.getRotation() != 0f) canvas.rotate(child.getRotation(), pivX, pivY);
+                                child.draw(canvas);
+                                canvas.restore();
+                            }
+                            writeBitmapToFile(owner, context, currentAttachment, editRequest, dialog, activeFilter, glBitmap);
+                        } else {
+                            Toast.makeText(context, "Failed to capture GL filter: " + copyResult, Toast.LENGTH_SHORT).show();
+                        }
+                    }, new android.os.Handler(android.os.Looper.getMainLooper()));
+                    return; // Async save handling
+                }
+            }
+
+            // Normal save for NONE or ColorMatrix filters (Full-res)
+            int outW = srcBitmap.getWidth();
+            int outH = srcBitmap.getHeight();
+            Bitmap saveBitmap = Bitmap.createBitmap(outW, outH, Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(saveBitmap);
+
+            Paint srcPaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.FILTER_BITMAP_FLAG);
+            float[] matrix = isCustomFilter != null && isCustomFilter[0] ? PhotoEditorUtils.buildCustomMatrix(customFilterValues) : PhotoEditorUtils.getColorMatrixForFilter(activeFilter);
+
+            boolean applyToEverything = owner.getSettings().getInt("filter_apply_mode", 0) == 1;
+
+            if (matrix != null && !applyToEverything) {
+                srcPaint.setColorFilter(new android.graphics.ColorMatrixColorFilter(matrix));
+            }
+            canvas.drawBitmap(srcBitmap, 0, 0, srcPaint);
+
+            float scaleX = (float) outW / Math.max(1, editorView.getWidth());
+            float scaleY = (float) outH / Math.max(1, editorView.getHeight());
+            canvas.save();
+            canvas.scale(scaleX, scaleY);
+            for (int i = 0; i < editorView.getChildCount(); i++) {
+                View child = editorView.getChildAt(i);
+                if (child == editorView.getSource()) continue;
+                if (child.getClass().getName().contains("ImageFilterView")) continue;
+                canvas.save();
+                canvas.translate(child.getX(), child.getY());
+                float pivX = child.getPivotX();
+                float pivY = child.getPivotY();
+                canvas.scale(child.getScaleX(), child.getScaleY(), pivX, pivY);
+                if (child.getRotation() != 0f) canvas.rotate(child.getRotation(), pivX, pivY);
+                child.draw(canvas);
+                canvas.restore();
+            }
+            canvas.restore();
+
+            if (matrix != null && applyToEverything) {
+                Bitmap finalSaveBitmap = Bitmap.createBitmap(outW, outH, Bitmap.Config.ARGB_8888);
+                Canvas finalCanvas = new Canvas(finalSaveBitmap);
+                Paint finalPaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.FILTER_BITMAP_FLAG);
+                finalPaint.setColorFilter(new android.graphics.ColorMatrixColorFilter(matrix));
+                finalCanvas.drawBitmap(saveBitmap, 0, 0, finalPaint);
+                saveBitmap.recycle();
+                saveBitmap = finalSaveBitmap;
+            }
+
+            writeBitmapToFile(owner, context, currentAttachment, editRequest, dialog, activeFilter, saveBitmap);
+        } catch (Throwable throwable) {
+            owner.logError(throwable);
+            Toast.makeText(context, "Failed to render image: " + throwable.getMessage(), Toast.LENGTH_LONG).show();
+        }
+    }
+
+    private static void writeBitmapToFile(PhotoEditorPlugin owner, Context context, Attachment<?>[] currentAttachment, PhotoEditorPlugin.EditRequest editRequest, Dialog dialog, PhotoFilter activeFilter, Bitmap finalBitmap) {
+        Utils.threadPool.execute(() -> {
+            try {
+                Attachment<?> original = currentAttachment[0];
+                File output = PhotoEditorUtils.nextOutputFile(context, original.getDisplayName());
+                try (FileOutputStream stream = new FileOutputStream(output)) {
+                    finalBitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
+                }
+
+                Attachment<?> edited = new Attachment<>(
+                        output.getAbsolutePath().hashCode(),
+                        Uri.fromFile(output),
+                        output.getName(),
+                        null,
+                        original.getSpoiler()
+                );
+
+                String filterDesc = (activeFilter != null && activeFilter != PhotoFilter.NONE)
+                        ? " (" + PhotoEditorUtils.humanize(activeFilter.name()) + " filter)" : "";
+                Utils.mainThread.post(() -> {
+                    editRequest.onEdited(original, edited);
+                    Toast.makeText(context, "Saved" + filterDesc, Toast.LENGTH_SHORT).show();
+                    dialog.dismiss();
+                });
+            } catch (Throwable throwable) {
+                owner.logError(throwable);
+                Utils.mainThread.post(() -> Toast.makeText(context, "Failed to save image", Toast.LENGTH_SHORT).show());
+            }
+        });
+    }
+
+    /**
+     * Maps a PhotoFilter to a 4×5 ColorMatrix array for software rendering.
+     * Returns null for NONE or filters without a meaningful color matrix equivalent.
+     */
+}

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSession.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSession.java
@@ -1,0 +1,219 @@
+package com.aliucord.plugins.photoeditor;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.aliucord.Utils;
+import com.lytefast.flexinput.model.Attachment;
+import com.lytefast.flexinput.utils.SelectionAggregator;
+
+import ja.burhanrashid52.photoeditor.PhotoEditor;
+import ja.burhanrashid52.photoeditor.PhotoEditorView;
+import ja.burhanrashid52.photoeditor.PhotoFilter;
+
+final class PhotoEditorSession {
+    private PhotoEditorSession() {}
+
+    static void open(
+            PhotoEditorPlugin owner,
+            Activity passedActivity,
+            Attachment<?> attachment,
+            PhotoEditorPlugin.EditRequest editRequest,
+            SelectionAggregator<?> aggregator
+    ) {
+        final Activity activity;
+        if (passedActivity == null || passedActivity.isFinishing() ||
+                (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1 && passedActivity.isDestroyed())) {
+            activity = Utils.getAppActivity();
+        } else {
+            activity = passedActivity;
+        }
+
+        if (activity == null || activity.isFinishing() ||
+                (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1 && activity.isDestroyed())) {
+            Activity appActivity = Utils.getAppActivity();
+            if (appActivity != null) {
+                Toast.makeText(appActivity, "Could not open image editor (activity null or destroyed)", Toast.LENGTH_SHORT).show();
+            }
+            return;
+        }
+        if (attachment.getUri() == null) {
+            Toast.makeText(activity, "Attachment has no URI", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        Dialog dialog = new Dialog(activity, android.R.style.Theme_Translucent_NoTitleBar_Fullscreen);
+        PhotoEditorView editorView = new PhotoEditorView(activity);
+        PhotoEditor editor = new PhotoEditor.Builder(activity, editorView)
+                .setPinchTextScalable(true)
+                .setClipSourceImage(false)
+                .build();
+
+        Attachment<?>[] currentAttachment = {attachment};
+        PhotoFilter[] sessionFilter = {PhotoFilter.NONE};
+        boolean[] isCustomFilter = {false};
+        float[] customFilterValues = {0f, 1f, 1f, 0f, 0f, 0f};
+
+        FrameLayout spoilerOverlay = new FrameLayout(activity);
+        spoilerOverlay.setBackgroundColor(0x99000000);
+
+        TextView spoilerText = new TextView(activity);
+        spoilerText.setText("SPOILER");
+        spoilerText.setTextColor(Color.WHITE);
+        spoilerText.setTextSize(24f);
+        spoilerText.setTypeface(null, android.graphics.Typeface.BOLD);
+        spoilerText.setPadding(owner.dp(20), owner.dp(8), owner.dp(20), owner.dp(8));
+
+        android.graphics.drawable.GradientDrawable pill = new android.graphics.drawable.GradientDrawable();
+        pill.setColor(0x80000000);
+        pill.setCornerRadius(owner.dp(20));
+        spoilerText.setBackground(pill);
+
+        spoilerOverlay.addView(spoilerText, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                Gravity.CENTER
+        ));
+        spoilerOverlay.setVisibility(attachment.getSpoiler() ? View.VISIBLE : View.GONE);
+
+        FrameLayout root = new FrameLayout(activity) {
+            @Override
+            public boolean dispatchTouchEvent(android.view.MotionEvent event) {
+                if (event.getAction() == android.view.MotionEvent.ACTION_DOWN &&
+                        spoilerOverlay.getVisibility() == View.VISIBLE && spoilerOverlay.getAlpha() == 1f) {
+                    spoilerOverlay.animate().alpha(0f).setDuration(150).withEndAction(() -> {
+                        spoilerOverlay.setVisibility(View.GONE);
+                        spoilerOverlay.setAlpha(1f);
+                    }).start();
+                }
+                return super.dispatchTouchEvent(event);
+            }
+        };
+        root.setBackgroundColor(0xff111214);
+
+        LinearLayout content = new LinearLayout(activity);
+        content.setOrientation(LinearLayout.VERTICAL);
+        root.addView(content, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+        ));
+
+        View header = PhotoEditorHeader.create(owner, activity, currentAttachment, aggregator, view -> dialog.dismiss(), isSpoiler -> {
+            if (isSpoiler) {
+                spoilerOverlay.setVisibility(View.VISIBLE);
+                spoilerOverlay.setAlpha(0f);
+                spoilerOverlay.animate().alpha(1f).setDuration(150).setListener(null).start();
+            } else if (spoilerOverlay.getVisibility() == View.VISIBLE) {
+                spoilerOverlay.animate().alpha(0f).setDuration(150).withEndAction(() -> {
+                    spoilerOverlay.setVisibility(View.GONE);
+                    spoilerOverlay.setAlpha(1f);
+                }).start();
+            }
+        });
+
+        android.widget.ImageView saveButton = new android.widget.ImageView(activity);
+        int saveId = Utils.getResId("ic_check_white_24dp", "drawable");
+        saveButton.setImageResource(saveId != 0 ? saveId : android.R.drawable.ic_menu_save);
+        saveButton.setColorFilter(Color.WHITE);
+        saveButton.setPadding(owner.dp(8), owner.dp(8), owner.dp(8), owner.dp(8));
+        owner.addRippleBorderless(saveButton);
+        owner.addPressAnimation(saveButton);
+        saveButton.setOnClickListener(view -> PhotoEditorSaver.save(
+                owner,
+                activity,
+                editor,
+                editorView,
+                currentAttachment,
+                editRequest,
+                dialog,
+                sessionFilter,
+                isCustomFilter,
+                customFilterValues
+        ));
+
+        LinearLayout.LayoutParams saveParams = new LinearLayout.LayoutParams(owner.dp(40), owner.dp(40));
+        saveParams.setMargins(owner.dp(8), 0, 0, 0);
+        ((LinearLayout) header).addView(saveButton, saveParams);
+
+        content.addView(header, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        FrameLayout editorHolder = new FrameLayout(activity);
+        editorHolder.setBackgroundColor(Color.BLACK);
+        content.addView(editorHolder, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                0,
+                1f
+        ));
+        editorHolder.addView(editorView, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                Gravity.CENTER
+        ));
+        editorHolder.addView(spoilerOverlay, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+        ));
+
+        ProgressBar progressBar = new ProgressBar(activity);
+        editorHolder.addView(progressBar, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                Gravity.CENTER
+        ));
+
+        content.addView(owner.createToolbar(
+                activity,
+                editor,
+                editorView,
+                dialog,
+                currentAttachment,
+                editRequest,
+                sessionFilter,
+                isCustomFilter,
+                customFilterValues
+        ), new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        dialog.setContentView(root);
+        Window window = dialog.getWindow();
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+            window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
+        }
+
+        dialog.setOnShowListener(ignored -> {
+            Window shownWindow = dialog.getWindow();
+            if (shownWindow != null) {
+                shownWindow.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
+            }
+            owner.loadImage(currentAttachment[0].getUri(), editorView, editorHolder, progressBar);
+            owner.applyBrush(editor);
+        });
+        dialog.setOnDismissListener(ignored -> owner.setEditorStickerPickerOpen(false));
+
+        try {
+            owner.setEditorStickerPickerOpen(true);
+            dialog.show();
+        } catch (android.view.WindowManager.BadTokenException exception) {
+            owner.setEditorStickerPickerOpen(false);
+            owner.logError("Failed to show PhotoEditor dialog because the activity window token is invalid", exception);
+            Toast.makeText(activity, "Could not open image editor", Toast.LENGTH_SHORT).show();
+        }
+    }
+}

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSettings.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSettings.java
@@ -3,7 +3,7 @@ package com.aliucord.plugins.photoeditor;
 import android.annotation.SuppressLint;
 import android.os.Bundle;
 import android.view.View;
-import android.widget.LinearLayout;
+
 
 import com.aliucord.Utils;
 import com.aliucord.api.SettingsAPI;

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSettings.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSettings.java
@@ -60,6 +60,32 @@ public class PhotoEditorSettings extends BottomSheet {
             builder.show();
         });
         addView(brushModeText);
+
+        int currentFilterMode = settings.getInt("filter_apply_mode", 0);
+        android.widget.TextView filterModeText = new android.widget.TextView(ctx);
+        filterModeText.setText("Filter Apply Mode: " + getFilterModeString(currentFilterMode));
+        filterModeText.setTextSize(16f);
+        filterModeText.setPadding(com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16));
+        filterModeText.setOnClickListener(v -> {
+            android.app.AlertDialog.Builder builder = new android.app.AlertDialog.Builder(ctx);
+            builder.setTitle("Filter Apply Mode");
+            String[] options = {"Canvas Only (Background Image)", "Entire Edited Image (Includes Stickers & Text)"};
+            builder.setSingleChoiceItems(options, settings.getInt("filter_apply_mode", 0), (dialog, which) -> {
+                settings.setInt("filter_apply_mode", which);
+                filterModeText.setText("Filter Apply Mode: " + getFilterModeString(which));
+                dialog.dismiss();
+            });
+            builder.show();
+        });
+        addView(filterModeText);
+    }
+
+    private String getFilterModeString(int mode) {
+        switch (mode) {
+            case 0: return "Canvas Only";
+            case 1: return "Entire Edited Image";
+            default: return "Unknown";
+        }
     }
 
     private String getModeString(int mode) {

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSettings.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSettings.java
@@ -1,0 +1,46 @@
+package com.aliucord.plugins.photoeditor;
+
+import android.annotation.SuppressLint;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.LinearLayout;
+
+import com.aliucord.Utils;
+import com.aliucord.api.SettingsAPI;
+import com.aliucord.widgets.BottomSheet;
+import com.discord.views.CheckedSetting;
+
+@SuppressWarnings("unused")
+@SuppressLint("SetTextI18n")
+public class PhotoEditorSettings extends BottomSheet {
+
+    private final SettingsAPI settings;
+
+    public PhotoEditorSettings(SettingsAPI settings) {
+        this.settings = settings;
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        
+        android.content.Context ctx = view.getContext();
+
+        try {
+            CheckedSetting quickEditSetting = Utils.createCheckedSetting(ctx, CheckedSetting.ViewType.SWITCH, "Quick Edit from Chat Input", "Instantly open the editor when tapping an image in the chat box, bypassing the attachment bottom sheet.");
+            quickEditSetting.setChecked(settings.getBool("quick_edit", false));
+            quickEditSetting.setOnCheckedListener(isChecked -> {
+                settings.setBool("quick_edit", isChecked);
+            });
+            addView(quickEditSetting);
+        } catch (Throwable t) {
+            // Fallback in case CheckedSetting API is different
+            android.widget.Switch sw = new android.widget.Switch(ctx);
+            sw.setText("Quick Edit from Chat Input (Bypass Bottom Sheet)");
+            sw.setChecked(settings.getBool("quick_edit", false));
+            sw.setOnCheckedChangeListener((btn, isChecked) -> settings.setBool("quick_edit", isChecked));
+            sw.setPadding(com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16));
+            addView(sw);
+        }
+    }
+}

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSettings.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSettings.java
@@ -42,5 +42,32 @@ public class PhotoEditorSettings extends BottomSheet {
             sw.setPadding(com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16));
             addView(sw);
         }
+
+        int currentMode = settings.getInt("brush_layer_mode", 2);
+        android.widget.TextView brushModeText = new android.widget.TextView(ctx);
+        brushModeText.setText("Brush Layer Mode: " + getModeString(currentMode));
+        brushModeText.setTextSize(16f);
+        brushModeText.setPadding(com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16));
+        brushModeText.setOnClickListener(v -> {
+            android.app.AlertDialog.Builder builder = new android.app.AlertDialog.Builder(ctx);
+            builder.setTitle("Brush Layer Mode");
+            String[] options = {"Always Behind Items", "Always In Front of Items", "Dynamic (Brings to front when drawing)"};
+            builder.setSingleChoiceItems(options, settings.getInt("brush_layer_mode", 2), (dialog, which) -> {
+                settings.setInt("brush_layer_mode", which);
+                brushModeText.setText("Brush Layer Mode: " + getModeString(which));
+                dialog.dismiss();
+            });
+            builder.show();
+        });
+        addView(brushModeText);
+    }
+
+    private String getModeString(int mode) {
+        switch (mode) {
+            case 0: return "Always Behind Items";
+            case 1: return "Always In Front of Items";
+            case 2: return "Dynamic (Brings to front when drawing)";
+            default: return "Unknown";
+        }
     }
 }

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSettings.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSettings.java
@@ -64,14 +64,24 @@ public class PhotoEditorSettings extends BottomSheet {
 
     private void addRadioGroup(String title, String[] labels, String[] descriptions, int selectedIndex, SelectionListener listener) {
         int safeSelectedIndex = Math.max(0, Math.min(selectedIndex, labels.length - 1));
+        android.widget.TextView header = new android.widget.TextView(requireContext());
+        header.setText(title);
+        header.setTextColor(android.graphics.Color.WHITE);
+        int headerStyle = Utils.getResId("UiKit_Settings_Item_Header", "style");
+        if (headerStyle != 0) {
+            header.setTextAppearance(requireContext(), headerStyle);
+        }
+        int horizontalPadding = com.aliucord.utils.DimenUtils.dpToPx(16);
+        header.setPadding(horizontalPadding, com.aliucord.utils.DimenUtils.dpToPx(16), horizontalPadding, com.aliucord.utils.DimenUtils.dpToPx(4));
+        addView(header);
+
         CheckedSetting[] options = new CheckedSetting[labels.length];
         List<Checkable> radioButtons = new ArrayList<>();
-
         for (int index = 0; index < labels.length; index++) {
             CheckedSetting option = Utils.createCheckedSetting(
                     requireContext(),
                     CheckedSetting.ViewType.RADIO,
-                    title + ": " + labels[index],
+                    labels[index],
                     descriptions[index]
             );
             option.setChecked(index == safeSelectedIndex);

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSettings.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorSettings.java
@@ -3,12 +3,16 @@ package com.aliucord.plugins.photoeditor;
 import android.annotation.SuppressLint;
 import android.os.Bundle;
 import android.view.View;
-
+import android.widget.Checkable;
 
 import com.aliucord.Utils;
 import com.aliucord.api.SettingsAPI;
 import com.aliucord.widgets.BottomSheet;
 import com.discord.views.CheckedSetting;
+import com.discord.views.RadioManager;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @SuppressWarnings("unused")
 @SuppressLint("SetTextI18n")
@@ -23,77 +27,73 @@ public class PhotoEditorSettings extends BottomSheet {
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        
-        android.content.Context ctx = view.getContext();
 
-        try {
-            CheckedSetting quickEditSetting = Utils.createCheckedSetting(ctx, CheckedSetting.ViewType.SWITCH, "Quick Edit from Chat Input", "Instantly open the editor when tapping an image in the chat box, bypassing the attachment bottom sheet.");
-            quickEditSetting.setChecked(settings.getBool("quick_edit", false));
-            quickEditSetting.setOnCheckedListener(isChecked -> {
-                settings.setBool("quick_edit", isChecked);
-            });
-            addView(quickEditSetting);
-        } catch (Throwable t) {
-            // Fallback in case CheckedSetting API is different
-            android.widget.Switch sw = new android.widget.Switch(ctx);
-            sw.setText("Quick Edit from Chat Input (Bypass Bottom Sheet)");
-            sw.setChecked(settings.getBool("quick_edit", false));
-            sw.setOnCheckedChangeListener((btn, isChecked) -> settings.setBool("quick_edit", isChecked));
-            sw.setPadding(com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16));
-            addView(sw);
-        }
+        CheckedSetting quickEditSetting = Utils.createCheckedSetting(
+                view.getContext(),
+                CheckedSetting.ViewType.SWITCH,
+                "Quick Edit from Chat Input",
+                "Open the editor when tapping an image in the chat box, without opening the attachment sheet."
+        );
+        quickEditSetting.setChecked(settings.getBool("quick_edit", false));
+        quickEditSetting.setOnCheckedListener(isChecked -> settings.setBool("quick_edit", isChecked));
+        addView(quickEditSetting);
 
-        int currentMode = settings.getInt("brush_layer_mode", 2);
-        android.widget.TextView brushModeText = new android.widget.TextView(ctx);
-        brushModeText.setText("Brush Layer Mode: " + getModeString(currentMode));
-        brushModeText.setTextSize(16f);
-        brushModeText.setPadding(com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16));
-        brushModeText.setOnClickListener(v -> {
-            android.app.AlertDialog.Builder builder = new android.app.AlertDialog.Builder(ctx);
-            builder.setTitle("Brush Layer Mode");
-            String[] options = {"Always Behind Items", "Always In Front of Items", "Dynamic (Brings to front when drawing)"};
-            builder.setSingleChoiceItems(options, settings.getInt("brush_layer_mode", 2), (dialog, which) -> {
-                settings.setInt("brush_layer_mode", which);
-                brushModeText.setText("Brush Layer Mode: " + getModeString(which));
-                dialog.dismiss();
-            });
-            builder.show();
-        });
-        addView(brushModeText);
+        addRadioGroup(
+                "Brush Layer Mode",
+                new String[]{"Always Behind Items", "Always In Front of Items", "Dynamic"},
+                new String[]{
+                        "Brush strokes stay behind text, stickers, and images.",
+                        "Brush strokes are drawn above text, stickers, and images.",
+                        "Bring brush strokes forward while drawing."
+                },
+                settings.getInt("brush_layer_mode", 2),
+                mode -> settings.setInt("brush_layer_mode", mode)
+        );
 
-        int currentFilterMode = settings.getInt("filter_apply_mode", 0);
-        android.widget.TextView filterModeText = new android.widget.TextView(ctx);
-        filterModeText.setText("Filter Apply Mode: " + getFilterModeString(currentFilterMode));
-        filterModeText.setTextSize(16f);
-        filterModeText.setPadding(com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16), com.aliucord.utils.DimenUtils.dpToPx(16));
-        filterModeText.setOnClickListener(v -> {
-            android.app.AlertDialog.Builder builder = new android.app.AlertDialog.Builder(ctx);
-            builder.setTitle("Filter Apply Mode");
-            String[] options = {"Canvas Only (Background Image)", "Entire Edited Image (Includes Stickers & Text)"};
-            builder.setSingleChoiceItems(options, settings.getInt("filter_apply_mode", 0), (dialog, which) -> {
-                settings.setInt("filter_apply_mode", which);
-                filterModeText.setText("Filter Apply Mode: " + getFilterModeString(which));
-                dialog.dismiss();
-            });
-            builder.show();
-        });
-        addView(filterModeText);
+        addRadioGroup(
+                "Filter Apply Mode",
+                new String[]{"Canvas Only", "Entire Edited Image"},
+                new String[]{
+                        "Apply filters only to the background image.",
+                        "Apply filters to the background, text, stickers, and other edits."
+                },
+                settings.getInt("filter_apply_mode", 0),
+                mode -> settings.setInt("filter_apply_mode", mode)
+        );
     }
 
-    private String getFilterModeString(int mode) {
-        switch (mode) {
-            case 0: return "Canvas Only";
-            case 1: return "Entire Edited Image";
-            default: return "Unknown";
+    private void addRadioGroup(String title, String[] labels, String[] descriptions, int selectedIndex, SelectionListener listener) {
+        int safeSelectedIndex = Math.max(0, Math.min(selectedIndex, labels.length - 1));
+        CheckedSetting[] options = new CheckedSetting[labels.length];
+        List<Checkable> radioButtons = new ArrayList<>();
+
+        for (int index = 0; index < labels.length; index++) {
+            CheckedSetting option = Utils.createCheckedSetting(
+                    requireContext(),
+                    CheckedSetting.ViewType.RADIO,
+                    title + ": " + labels[index],
+                    descriptions[index]
+            );
+            option.setChecked(index == safeSelectedIndex);
+            options[index] = option;
+            radioButtons.add(option);
+            addView(option);
+        }
+
+        RadioManager radioManager = new RadioManager(radioButtons);
+        for (int index = 0; index < options.length; index++) {
+            final int optionIndex = index;
+            final CheckedSetting option = options[index];
+            option.setOnCheckedListener(isChecked -> {
+                if (isChecked) {
+                    radioManager.a(option);
+                    listener.onSelected(optionIndex);
+                }
+            });
         }
     }
 
-    private String getModeString(int mode) {
-        switch (mode) {
-            case 0: return "Always Behind Items";
-            case 1: return "Always In Front of Items";
-            case 2: return "Dynamic (Brings to front when drawing)";
-            default: return "Unknown";
-        }
+    private interface SelectionListener {
+        void onSelected(int index);
     }
 }

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorTextDialog.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorTextDialog.java
@@ -1,0 +1,437 @@
+package com.aliucord.plugins.photoeditor;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.ImageDecoder;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.graphics.drawable.ColorDrawable;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Environment;
+import android.text.InputType;
+import android.view.Gravity;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.widget.AppCompatTextView;
+import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import com.aliucord.Utils;
+import com.aliucord.annotations.AliucordPlugin;
+import com.aliucord.entities.Plugin;
+import com.aliucord.patcher.Hook;
+import com.aliucord.patcher.InsteadHook;
+import com.aliucord.patcher.PreHook;
+import com.aliucord.utils.DimenUtils;
+import com.discord.api.channel.Channel;
+import com.discord.api.message.attachment.MessageAttachment;
+import com.discord.api.message.attachment.MessageAttachmentType;
+import com.discord.api.sticker.Sticker;
+import com.discord.models.domain.emoji.Emoji;
+import com.discord.models.message.Message;
+import com.discord.stores.StoreStream;
+import com.discord.utilities.stickers.StickerUtils;
+import com.discord.widgets.chat.input.WidgetChatInputAttachments;
+import com.discord.widgets.chat.input.attachments.AttachmentBottomSheet;
+import com.discord.widgets.chat.input.emoji.EmojiPickerContextType;
+import com.discord.widgets.chat.input.emoji.EmojiPickerNavigator;
+import com.discord.widgets.chat.input.sticker.StickerPickerViewModel;
+import com.discord.widgets.chat.input.sticker.WidgetStickerPickerSheet;
+import com.discord.widgets.chat.list.adapter.WidgetChatListAdapterItemAttachment;
+import com.discord.widgets.chat.list.entries.AttachmentEntry;
+import com.discord.widgets.chat.list.entries.ChatListEntry;
+import com.discord.widgets.media.WidgetMedia;
+import com.lytefast.flexinput.fragment.FlexInputFragment;
+import com.lytefast.flexinput.model.Attachment;
+import com.lytefast.flexinput.utils.SelectionAggregator;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import de.robv.android.xposed.XposedBridge;
+import ja.burhanrashid52.photoeditor.PhotoEditor;
+import ja.burhanrashid52.photoeditor.PhotoEditorView;
+import ja.burhanrashid52.photoeditor.PhotoFilter;
+import ja.burhanrashid52.photoeditor.shape.ShapeBuilder;
+import kotlin.Unit;
+
+final class PhotoEditorTextDialog {
+    private PhotoEditorTextDialog() {}
+
+    static void show(PhotoEditorPlugin owner, Context context, PhotoEditor editor, PhotoEditorView editorView) {
+        Dialog dialog = new Dialog(context);
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+
+        LinearLayout layout = owner.createBottomSheetContainer(context);
+
+        // State variables
+        final int[] currentTextColor = {owner.getTextColor()};
+        final float[] currentTextSize = {28f};
+        final String[] currentFontFamily = {"sans-serif"};
+        final boolean[] isBold = {false};
+        final boolean[] isItalic = {false};
+        final boolean[] isUnderlined = {false};
+        final android.graphics.Typeface[] finalTypeface = {android.graphics.Typeface.DEFAULT};
+
+        final java.util.Map<String, String> fontPathMap = new java.util.HashMap<>();
+        String[] defaultFonts = {"sans-serif", "sans-serif-thin", "sans-serif-light", "sans-serif-medium", "sans-serif-black", "sans-serif-condensed", "sans-serif-condensed-light", "sans-serif-condensed-medium", "serif", "monospace", "serif-monospace", "casual", "cursive", "sans-serif-smallcaps"};
+        final java.util.List<String> fontList = new java.util.ArrayList<>(java.util.Arrays.asList(defaultFonts));
+
+        class FontScanner {
+            void scan(java.io.File dir, int depth) {
+                if (depth > 2 || dir == null || !dir.exists() || !dir.isDirectory()) return;
+                java.io.File[] files = dir.listFiles();
+                if (files != null) {
+                    for (java.io.File f : files) {
+                        if (f.isDirectory()) {
+                            scan(f, depth + 1);
+                        } else if (f.isFile() && (f.getName().endsWith(".ttf") || f.getName().endsWith(".otf"))) {
+                            String name = f.getName();
+                            String cleanName = name.substring(0, name.lastIndexOf('.'));
+                            fontList.add(cleanName);
+                            fontPathMap.put(cleanName, f.getAbsolutePath());
+                        }
+                    }
+                }
+            }
+        }
+        new FontScanner().scan(new java.io.File("/system/fonts"), 0);
+        new FontScanner().scan(new java.io.File(Environment.getExternalStorageDirectory(), "Fonts"), 0);
+        new FontScanner().scan(new java.io.File(Environment.getExternalStorageDirectory(), "Aliucord/fonts"), 0);
+
+        EditText input = owner.dialogInput(context, "Enter your text...");
+        android.graphics.drawable.GradientDrawable inputBg = new android.graphics.drawable.GradientDrawable();
+        inputBg.setColor(0xff1e1f22);
+        inputBg.setCornerRadius(owner.dp(8));
+        inputBg.setStroke(owner.dp(1), Color.parseColor("#3f4147"));
+        input.setBackground(inputBg);
+        input.setTextColor(currentTextColor[0]);
+        input.setHintTextColor(Color.parseColor("#80848e"));
+        input.setTextSize(currentTextSize[0]);
+        input.setMinLines(2);
+        input.setGravity(Gravity.TOP | Gravity.START);
+        input.setPadding(owner.dp(12), owner.dp(12), owner.dp(12), owner.dp(12));
+
+        Runnable updateTypeface = () -> {
+            int style = android.graphics.Typeface.NORMAL;
+            if (isBold[0] && isItalic[0]) style = android.graphics.Typeface.BOLD_ITALIC;
+            else if (isBold[0]) style = android.graphics.Typeface.BOLD;
+            else if (isItalic[0]) style = android.graphics.Typeface.ITALIC;
+
+            try {
+                if (fontPathMap.containsKey(currentFontFamily[0])) {
+                    java.io.File f = new java.io.File(fontPathMap.get(currentFontFamily[0]));
+                    if (f.exists()) {
+                        finalTypeface[0] = android.graphics.Typeface.createFromFile(f);
+                        if (style != android.graphics.Typeface.NORMAL) {
+                            finalTypeface[0] = android.graphics.Typeface.create(finalTypeface[0], style);
+                        }
+                    } else {
+                        finalTypeface[0] = android.graphics.Typeface.create(currentFontFamily[0], style);
+                    }
+                } else if (currentFontFamily[0].endsWith(".ttf") || currentFontFamily[0].endsWith(".otf")) {
+                    java.io.File f = new java.io.File("/system/fonts/" + currentFontFamily[0]);
+                    if (f.exists()) {
+                        finalTypeface[0] = android.graphics.Typeface.createFromFile(f);
+                        if (style != android.graphics.Typeface.NORMAL) {
+                            finalTypeface[0] = android.graphics.Typeface.create(finalTypeface[0], style);
+                        }
+                    } else {
+                        finalTypeface[0] = android.graphics.Typeface.create(currentFontFamily[0], style);
+                    }
+                } else {
+                    finalTypeface[0] = android.graphics.Typeface.create(currentFontFamily[0], style);
+                }
+            } catch (Exception e) {
+                finalTypeface[0] = android.graphics.Typeface.create("sans-serif", style);
+            }
+            input.setTypeface(finalTypeface[0]);
+            input.setTextSize(currentTextSize[0]);
+            input.setTextColor(currentTextColor[0]);
+
+            if (isUnderlined[0]) {
+                input.setPaintFlags(input.getPaintFlags() | android.graphics.Paint.UNDERLINE_TEXT_FLAG);
+            } else {
+                input.setPaintFlags(input.getPaintFlags() & ~android.graphics.Paint.UNDERLINE_TEXT_FLAG);
+            }
+        };
+
+        LinearLayout.LayoutParams inputParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        inputParams.setMargins(0, 0, 0, owner.dp(16));
+        input.setLayoutParams(inputParams);
+        layout.addView(input);
+
+        // Wrap everything else in a ScrollView to prevent keyboard overlap
+        android.widget.ScrollView scrollView = new android.widget.ScrollView(context);
+        LinearLayout scrollContent = new LinearLayout(context);
+        scrollContent.setOrientation(LinearLayout.VERTICAL);
+
+        // Font Selection Row
+        android.widget.AutoCompleteTextView fontSearch = new android.widget.AutoCompleteTextView(context);
+
+        int bgColor = 0xff313338;
+        int textColorPrimary = Color.WHITE;
+        try {
+            android.util.TypedValue typedValue = new android.util.TypedValue();
+            int bgAttr = Utils.getResId("colorBackgroundFloating", "attr");
+            if (bgAttr != 0 && context.getTheme().resolveAttribute(bgAttr, typedValue, true)) {
+                bgColor = typedValue.data;
+            } else if (context.getTheme().resolveAttribute(android.R.attr.windowBackground, typedValue, true)) {
+                bgColor = typedValue.data;
+            }
+
+            int textAttr = Utils.getResId("colorTextNormal", "attr");
+            if (textAttr != 0 && context.getTheme().resolveAttribute(textAttr, typedValue, true)) {
+                textColorPrimary = typedValue.data;
+            } else if (context.getTheme().resolveAttribute(android.R.attr.textColorPrimary, typedValue, true)) {
+                textColorPrimary = typedValue.data;
+            }
+        } catch (Exception ignored) {}
+        final int finalTextColor = textColorPrimary;
+
+        fontSearch.setTextColor(textColorPrimary);
+        fontSearch.setHint("Search font (e.g., sans-serif)");
+        fontSearch.setHintTextColor(Color.GRAY);
+        fontSearch.setSingleLine(true);
+        fontSearch.setText("sans-serif");
+        fontSearch.setThreshold(0); // Show dropdown even when empty
+        fontSearch.setDropDownHeight(owner.dp(150)); // Constrain height so it doesn't hide behind keyboard
+        fontSearch.setDropDownBackgroundDrawable(new android.graphics.drawable.ColorDrawable(bgColor)); // Match theme
+        fontSearch.setOnClickListener(v -> fontSearch.showDropDown());
+        fontSearch.setOnFocusChangeListener((v, hasFocus) -> { if (hasFocus) fontSearch.showDropDown(); });
+        android.widget.ArrayAdapter<String> adapter = new android.widget.ArrayAdapter<String>(context, android.R.layout.simple_dropdown_item_1line, fontList) {
+            @Override
+            public View getView(int position, View convertView, ViewGroup parent) {
+                TextView view = (TextView) super.getView(position, convertView, parent);
+                view.setTextColor(finalTextColor);
+                return view;
+            }
+        };
+        fontSearch.setAdapter(adapter);
+
+        fontSearch.addTextChangedListener(new android.text.TextWatcher() {
+            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override public void onTextChanged(CharSequence s, int start, int before, int count) {}
+            @Override public void afterTextChanged(android.text.Editable s) {
+                currentFontFamily[0] = s.toString().trim();
+                updateTypeface.run();
+            }
+        });
+        fontSearch.setOnItemClickListener((parent, view, position, id) -> {
+            currentFontFamily[0] = adapter.getItem(position);
+            updateTypeface.run();
+        });
+
+        LinearLayout.LayoutParams searchParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        searchParams.setMargins(0, 0, 0, owner.dp(12));
+        scrollContent.addView(fontSearch, searchParams);
+
+        // Style Toggles Row
+        LinearLayout styleTogglesRow = new LinearLayout(context);
+        styleTogglesRow.setOrientation(LinearLayout.HORIZONTAL);
+        styleTogglesRow.setGravity(Gravity.START | Gravity.CENTER_VERTICAL);
+
+        // Bold Toggle
+        TextView boldToggle = new TextView(context);
+        boldToggle.setText("B");
+        boldToggle.setTextColor(Color.GRAY);
+        boldToggle.setTextSize(18f);
+        boldToggle.setTypeface(null, android.graphics.Typeface.BOLD);
+        boldToggle.setPadding(owner.dp(8), owner.dp(4), owner.dp(16), owner.dp(4));
+        boldToggle.setOnClickListener(v -> {
+            isBold[0] = !isBold[0];
+            boldToggle.setTextColor(isBold[0] ? Color.WHITE : Color.GRAY);
+            updateTypeface.run();
+        });
+        styleTogglesRow.addView(boldToggle);
+
+        // Italic Toggle
+        TextView italicToggle = new TextView(context);
+        italicToggle.setText("I");
+        italicToggle.setTextColor(Color.GRAY);
+        italicToggle.setTextSize(18f);
+        italicToggle.setTypeface(null, android.graphics.Typeface.ITALIC);
+        italicToggle.setPadding(owner.dp(16), owner.dp(4), owner.dp(16), owner.dp(4));
+        italicToggle.setOnClickListener(v -> {
+            isItalic[0] = !isItalic[0];
+            italicToggle.setTextColor(isItalic[0] ? Color.WHITE : Color.GRAY);
+            updateTypeface.run();
+        });
+        styleTogglesRow.addView(italicToggle);
+
+        // Underline Toggle
+        TextView underlineToggle = new TextView(context);
+        underlineToggle.setText("U");
+        underlineToggle.setTextColor(Color.GRAY);
+        underlineToggle.setTextSize(18f);
+        underlineToggle.setPaintFlags(underlineToggle.getPaintFlags() | android.graphics.Paint.UNDERLINE_TEXT_FLAG);
+        underlineToggle.setPadding(owner.dp(16), owner.dp(4), owner.dp(16), owner.dp(4));
+        underlineToggle.setOnClickListener(v -> {
+            isUnderlined[0] = !isUnderlined[0];
+            underlineToggle.setTextColor(isUnderlined[0] ? Color.WHITE : Color.GRAY);
+            updateTypeface.run();
+        });
+        styleTogglesRow.addView(underlineToggle);
+
+        LinearLayout.LayoutParams togglesRowParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        togglesRowParams.setMargins(0, 0, 0, owner.dp(12));
+        scrollContent.addView(styleTogglesRow, togglesRowParams);
+
+        // Size & Color Row
+        LinearLayout styleRow = new LinearLayout(context);
+        styleRow.setOrientation(LinearLayout.HORIZONTAL);
+        styleRow.setGravity(Gravity.CENTER_VERTICAL);
+        styleRow.setPadding(0, 0, 0, owner.dp(16));
+
+        TextView sizeLabel = new TextView(context);
+        sizeLabel.setText("Size " + (int) currentTextSize[0]);
+        sizeLabel.setTextColor(Color.parseColor("#b5bac1"));
+        sizeLabel.setTextSize(14f);
+        sizeLabel.setGravity(Gravity.END | Gravity.CENTER_VERTICAL);
+        sizeLabel.setMinimumWidth(owner.dp(65)); // Prevent layout jumping
+        styleRow.addView(sizeLabel);
+
+        com.google.android.material.slider.Slider sizeSlider = PhotoEditorUi.createDiscordSlider(context, 0, 110, currentTextSize[0] - 10);
+        sizeSlider.addOnChangeListener((slider, value, fromUser) -> {
+            currentTextSize[0] = Math.round(value) + 10f;
+            sizeLabel.setText("Size " + (int) currentTextSize[0]);
+            updateTypeface.run();
+        });
+        LinearLayout.LayoutParams sliderParams = new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
+        styleRow.addView(sizeSlider, sliderParams);
+
+        View colorBtn = owner.colorSwatch(context, currentTextColor[0], null);
+        colorBtn.setOnClickListener(v -> {
+            PhotoEditorColorPicker.show(context, editorView, editor, currentTextColor[0], PhotoEditorPlugin.COLORS, newColor -> {
+                currentTextColor[0] = newColor;
+                owner.setTextColor(newColor); // Also sync global text color
+                owner.setColorSwatchSelected(colorBtn, newColor, true);
+                updateTypeface.run();
+            });
+        });
+        LinearLayout.LayoutParams colorBtnParams = new LinearLayout.LayoutParams(owner.dp(32), owner.dp(32));
+        colorBtnParams.setMargins(owner.dp(12), 0, 0, 0);
+        colorBtn.setLayoutParams(colorBtnParams);
+        styleRow.addView(colorBtn);
+
+        scrollContent.addView(styleRow);
+
+        scrollView.addView(scrollContent);
+        LinearLayout.LayoutParams scrollParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        // We use weight=1f so that if the keyboard pushes it, it shrinks and becomes scrollable
+        scrollParams.weight = 1f;
+        layout.addView(scrollView, scrollParams);
+
+        updateTypeface.run();
+
+        // Buttons
+        LinearLayout buttons = new LinearLayout(context);
+        buttons.setOrientation(LinearLayout.HORIZONTAL);
+        buttons.setGravity(Gravity.RIGHT);
+
+        TextView cancelBtn = new TextView(context);
+        cancelBtn.setText("Cancel");
+        cancelBtn.setTextColor(Color.parseColor("#dbdee1"));
+        cancelBtn.setTextSize(14f);
+        cancelBtn.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
+        cancelBtn.setGravity(Gravity.CENTER);
+        cancelBtn.setPadding(owner.dp(16), owner.dp(11), owner.dp(16), owner.dp(11));
+        cancelBtn.setOnClickListener(v -> dialog.dismiss());
+        buttons.addView(cancelBtn);
+
+        TextView addBtn = new TextView(context);
+        addBtn.setText("Add");
+        addBtn.setTextColor(Color.WHITE);
+        addBtn.setTextSize(14f);
+        addBtn.setTypeface(android.graphics.Typeface.DEFAULT_BOLD);
+        addBtn.setGravity(Gravity.CENTER);
+        addBtn.setPadding(owner.dp(18), owner.dp(11), owner.dp(18), owner.dp(11));
+
+        android.graphics.drawable.GradientDrawable addBg = new android.graphics.drawable.GradientDrawable();
+        addBg.setColor(0xff5865f2);
+        addBg.setCornerRadius(owner.dp(8));
+        addBtn.setBackground(addBg);
+
+        addBtn.setOnClickListener(v -> {
+            String text = input.getText().toString().trim();
+            if (!text.isEmpty()) {
+                try {
+                    editor.setBrushDrawingMode(false);
+                    owner.addTextOverlay(editorView, text, currentTextColor[0], finalTypeface[0], currentTextSize[0], isUnderlined[0]);
+                } catch (Throwable t) {
+                    owner.logError("Failed to add text to canvas", t);
+                    android.widget.Toast.makeText(context, "Failed to add text: " + t.getMessage(), android.widget.Toast.LENGTH_LONG).show();
+                }
+            }
+            dialog.dismiss();
+        });
+
+        LinearLayout.LayoutParams addParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        addParams.setMargins(owner.dp(8), 0, 0, 0);
+        addBtn.setLayoutParams(addParams);
+        buttons.addView(addBtn);
+
+        layout.addView(buttons);
+
+        dialog.setContentView(layout);
+        Window window = dialog.getWindow();
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+            window.setGravity(Gravity.BOTTOM);
+            window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        }
+        dialog.setOnShowListener(ignored -> {
+            Window shownWindow = dialog.getWindow();
+            if (shownWindow != null) {
+                shownWindow.setGravity(Gravity.TOP | Gravity.CENTER_HORIZONTAL);
+                WindowManager.LayoutParams attributes = shownWindow.getAttributes();
+                attributes.y = owner.dp(72);
+                shownWindow.setAttributes(attributes);
+                shownWindow.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+                shownWindow.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE | WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+            }
+            input.requestFocus();
+        });
+        Window dialogWindow = dialog.getWindow();
+        if (dialogWindow != null)
+            dialogWindow.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE | WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+        dialog.show();
+    }
+
+}

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorUi.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorUi.java
@@ -1,0 +1,40 @@
+package com.aliucord.plugins.photoeditor;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Bitmap;
+import android.graphics.Color;
+
+import com.google.android.material.slider.Slider;
+
+final class PhotoEditorUi {
+    private PhotoEditorUi() {}
+
+    static Slider createDiscordSlider(Context context, float from, float to, float value) {
+        Slider slider = new Slider(context);
+        slider.setValueFrom(from);
+        slider.setValueTo(to);
+        slider.setStepSize(1f);
+        slider.setValue(value);
+        ColorStateList blurple = ColorStateList.valueOf(0xff5865f2);
+        slider.setThumbTintList(blurple);
+        slider.setTrackActiveTintList(blurple);
+        slider.setTrackInactiveTintList(ColorStateList.valueOf(0xff4e5058));
+        return slider;
+    }
+
+    static Bitmap createColorPlane(int size) {
+        int[] pixels = new int[size * size];
+        float[] hsv = new float[3];
+        for (int y = 0; y < size; y++) {
+            float position = y / (float) (size - 1);
+            hsv[1] = position <= 0.5f ? position * 2f : 1f;
+            hsv[2] = position <= 0.5f ? 1f : (1f - position) * 2f;
+            for (int x = 0; x < size; x++) {
+                hsv[0] = x / (float) (size - 1) * 360f;
+                pixels[y * size + x] = Color.HSVToColor(hsv);
+            }
+        }
+        return Bitmap.createBitmap(pixels, size, size, Bitmap.Config.ARGB_8888);
+    }
+}

--- a/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorUtils.java
+++ b/PhotoEditor/src/main/java/com/aliucord/plugins/photoeditor/PhotoEditorUtils.java
@@ -1,0 +1,220 @@
+package com.aliucord.plugins.photoeditor;
+
+import android.content.Context;
+import android.os.Environment;
+
+import java.io.File;
+import java.util.Locale;
+
+import ja.burhanrashid52.photoeditor.PhotoFilter;
+
+final class PhotoEditorUtils {
+    private PhotoEditorUtils() {}
+
+    static float[] getColorMatrixForFilter(PhotoFilter filter) {
+        if (filter == null || filter == PhotoFilter.NONE) return null;
+        switch (filter) {
+            case GRAY_SCALE:
+                return new float[]{
+                    0.21f, 0.72f, 0.07f, 0, 0,
+                    0.21f, 0.72f, 0.07f, 0, 0,
+                    0.21f, 0.72f, 0.07f, 0, 0,
+                    0,     0,     0,     1, 0
+                };
+            case SEPIA:
+                return new float[]{
+                    0.393f, 0.769f, 0.189f, 0, 0,
+                    0.349f, 0.686f, 0.168f, 0, 0,
+                    0.272f, 0.534f, 0.131f, 0, 0,
+                    0,      0,      0,      1, 0
+                };
+            case NEGATIVE:
+                return new float[]{
+                    -1,  0,  0, 0, 255,
+                     0, -1,  0, 0, 255,
+                     0,  0, -1, 0, 255,
+                     0,  0,  0, 1,   0
+                };
+            case BRIGHTNESS:
+                return new float[]{
+                    1, 0, 0, 0, 55,
+                    0, 1, 0, 0, 55,
+                    0, 0, 1, 0, 55,
+                    0, 0, 0, 1,  0
+                };
+            case CONTRAST: {
+                float s = 1.5f, t = (-.5f * s + .5f) * 255f;
+                return new float[]{
+                    s, 0, 0, 0, t,
+                    0, s, 0, 0, t,
+                    0, 0, s, 0, t,
+                    0, 0, 0, 1, 0
+                };
+            }
+            case SATURATE:
+                return new float[]{
+                     1.8f, -0.4f, -0.4f, 0, 0,
+                    -0.4f,  1.8f, -0.4f, 0, 0,
+                    -0.4f, -0.4f,  1.8f, 0, 0,
+                     0,     0,     0,    1, 0
+                };
+            case TEMPERATURE:
+                // Warm: boost red, reduce blue
+                return new float[]{
+                    1.15f, 0,    0,     0,  10,
+                    0,     1.0f, 0,     0,   0,
+                    0,     0,    0.75f, 0, -15,
+                    0,     0,    0,     1,   0
+                };
+            case TINT:
+                // Subtle cool tint
+                return new float[]{
+                    0.9f, 0,    0,    0, 0,
+                    0,    1.0f, 0,    0, 5,
+                    0,    0,    1.1f, 0, 10,
+                    0,    0,    0,    1, 0
+                };
+            case DUE_TONE:
+                // Duotone: map to teal-purple
+                return new float[]{
+                    0.3f, 0.5f, 0.2f, 0, 20,
+                    0.1f, 0.4f, 0.5f, 0, 30,
+                    0.4f, 0.2f, 0.4f, 0, 40,
+                    0,    0,    0,    1,  0
+                };
+            case LOMISH:
+                // Lo-fi: faded, slightly warm
+                return new float[]{
+                    0.9f, 0.1f, 0,    0, 20,
+                    0,    0.85f,0.1f, 0, 15,
+                    0.1f, 0,    0.8f, 0, 10,
+                    0,    0,    0,    1,  0
+                };
+            case POSTERIZE: {
+                // Crude posterize via high contrast + slight desaturate
+                float ps = 2.5f, pt = (-.5f * ps + .5f) * 255f;
+                return new float[]{
+                    ps, 0,  0,  0, pt,
+                    0,  ps, 0,  0, pt,
+                    0,  0,  ps, 0, pt,
+                    0,  0,  0,  1,  0
+                };
+            }
+            case GRAIN:
+                // Grain is random, can't do with ColorMatrix — return null
+                return null;
+            case FILL_LIGHT:
+                return new float[]{
+                    1, 0, 0, 0, 30,
+                    0, 1, 0, 0, 30,
+                    0, 0, 1, 0, 30,
+                    0, 0, 0, 1,  0
+                };
+            case FISH_EYE:
+                // Geometric distortion — not possible with ColorMatrix
+                return null;
+            case VIGNETTE:
+                // Radial effect — not possible with ColorMatrix
+                return null;
+            case DOCUMENTARY:
+                // Desaturated + high contrast
+                return new float[]{
+                    0.33f, 0.50f, 0.17f, 0,  0,
+                    0.33f, 0.50f, 0.17f, 0,  0,
+                    0.33f, 0.50f, 0.17f, 0,  0,
+                    0,     0,     0,     1, -5
+                };
+            case SHARPEN:
+                return null; // Convolution kernel — not possible with ColorMatrix
+            case AUTO_FIX:
+                return new float[]{
+                    1.1f, 0,    0,    0, 5,
+                    0,    1.1f, 0,    0, 5,
+                    0,    0,    1.1f, 0, 5,
+                    0,    0,    0,    1, 0
+                };
+            default:
+                return null;
+        }
+    }
+
+    static File nextOutputFile(Context context, String displayName) {
+        File dir = new File(context.getExternalFilesDir(Environment.DIRECTORY_PICTURES), "PhotoEditor");
+        if (!dir.exists() && !dir.mkdirs())
+            dir = context.getCacheDir();
+        return new File(dir, editedFileName(displayName));
+    }
+
+    static String editedFileName(String displayName) {
+        String baseName = displayName == null ? "image" : displayName.replaceAll("(?i)\\.[a-z0-9]{1,5}$", "");
+        baseName = baseName.replaceAll("[^A-Za-z0-9._-]", "_");
+        if (baseName.isEmpty())
+            baseName = "image";
+        return baseName + "-edited-" + System.currentTimeMillis() + ".png";
+    }
+
+        static String humanize(String name) {
+        String lower = name.toLowerCase(Locale.ROOT).replace('_', ' ');
+        return lower.substring(0, 1).toUpperCase(Locale.ROOT) + lower.substring(1);
+    }
+
+    static float[] buildCustomMatrix(float[] values) {
+        float brightness = values[0];
+        float contrast = values[1];
+        float saturation = values[2];
+        float hue = values[3];
+        float temp = values[4];
+        float tint = values[5];
+
+        android.graphics.ColorMatrix cm = new android.graphics.ColorMatrix();
+
+        // Brightness & Contrast
+        float t = (1f - contrast) * 128f + brightness;
+        android.graphics.ColorMatrix cmContrast = new android.graphics.ColorMatrix(new float[]{
+            contrast, 0, 0, 0, t,
+            0, contrast, 0, 0, t,
+            0, 0, contrast, 0, t,
+            0, 0, 0, 1, 0
+        });
+        cm.postConcat(cmContrast);
+
+        // Saturation
+        android.graphics.ColorMatrix cmSat = new android.graphics.ColorMatrix();
+        cmSat.setSaturation(saturation);
+        cm.postConcat(cmSat);
+
+        // Hue
+        if (hue != 0f) {
+            float cos = (float) Math.cos(hue * Math.PI / 180f);
+            float sin = (float) Math.sin(hue * Math.PI / 180f);
+            float lumR = 0.213f, lumG = 0.715f, lumB = 0.072f;
+            android.graphics.ColorMatrix cmHue = new android.graphics.ColorMatrix(new float[]{
+                lumR + cos * (1 - lumR) + sin * (-lumR), lumG + cos * (-lumG) + sin * (-lumG), lumB + cos * (-lumB) + sin * (1 - lumB), 0, 0,
+                lumR + cos * (-lumR) + sin * (0.143f), lumG + cos * (1 - lumG) + sin * (0.140f), lumB + cos * (-lumB) + sin * (-0.283f), 0, 0,
+                lumR + cos * (-lumR) + sin * (-(1 - lumR)), lumG + cos * (-lumG) + sin * (lumG), lumB + cos * (1 - lumB) + sin * (lumB), 0, 0,
+                0, 0, 0, 1, 0
+            });
+            cm.postConcat(cmHue);
+        }
+
+        // Temperature (Warm/Cool) & Tint (Green/Magenta)
+        if (temp != 0f || tint != 0f) {
+            float rTemp = temp > 0 ? temp * 0.1f : 0;
+            float bTemp = temp < 0 ? -temp * 0.1f : 0;
+            float gTint = tint > 0 ? tint * 0.1f : 0;
+            float rTint = tint < 0 ? -tint * 0.1f : 0;
+            float bTint = tint < 0 ? -tint * 0.1f : 0;
+
+            android.graphics.ColorMatrix cmTempTint = new android.graphics.ColorMatrix(new float[]{
+                1f + rTemp + rTint, 0, 0, 0, 0,
+                0, 1f + gTint, 0, 0, 0,
+                0, 0, 1f + bTemp + bTint, 0, 0,
+                0, 0, 0, 1, 0
+            });
+            cm.postConcat(cmTempTint);
+        }
+
+        return cm.getArray();
+    }
+
+}


### PR DESCRIPTION
## Overview
This PR introduces PhotoEditor v2.0.0, completely overhauling the v1 foundation with a much cleaner native UI, brand new features, and major stability fixes to prevent crashes on high-res images.

### Key Features Added Since v1
* **Settings Page & Quick Edit:** Added a dedicated settings page. You can now enable "Quick Edit" to bypass the attachment menu and instantly edit images when tapped.
* **Custom Color Filters:** Replaced static presets with a 6-slider custom `ColorMatrix` engine (Brightness, Contrast, Saturation, Hue, Temp, Tint). 
* **Brush Layer Modes:** Added a setting to control the brush Z-index. You can now choose to draw behind stickers, in front of them, or dynamically weave strokes between them.
* **Filter Apply Modes:** Added a setting to choose if filters apply globally (over stickers) or just to the background image.
* **Advanced Cropping:** Upgraded the crop tool with a lag-free real-time rotation slider, mirroring, and quick-snap rotation.
* **Overlay Management:** You can now long-press any sticker, emoji, or pasted image on the canvas to open a menu to individually crop, rotate, or delete it.
* **Custom Typography:** The text tool now recursively loads custom `.ttf` and `.otf` fonts from your device and features a live preview.
* **Advanced Color Picker:** Swapped the basic palette for a massive HSV color picker with hex input and an eyedropper tool.

### UI & UX
* **Native Feel:** Replaced all placeholder icons with native Discord vectors. 
* **Layout Polish:** Replaced clunky brush buttons with a smooth slider, added long-press tooltips to all buttons, and moved Save/Delete/Spoiler to the top header for instant access.
* **Global Undo/Redo:** Undo and Redo are now global top-bar actions that dynamically grey out when there's nothing to undo.

### Major Bug Fixes
* **Crop Lag / OOM Fix:** Engineered a downscaled proxy renderer so rotating massive images no longer lags or crashes the app.
* **FakeStickers Fix:** Hooked into `StickerPickerViewModel` so picking a sticker inside the editor doesn't accidentally send it to the chat.
* **Activity Crashes:** Bulletproofed the Activity context to stop random "Could not open image editor" window token crashes.
* **UI Sync:** Fixed a bug where the Pen tool would visually stay highlighted even after the library disabled drawing mode.

---

*Note: The code for this update was slopified using Gemini 3.1 Pro, Cause yeah.*